### PR TITLE
Add lock template for handling topic property locking

### DIFF
--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -186,17 +186,21 @@ init 0 python:
         def __load(self):
             """
             Internal load funtion
+
+            NOTE: Will raise a KeyError of the lock map doesn't have the persist key in it
             """
             for persist_key, value in self.__persistent_db[self.label].iteritems():
-                if TOPIC_LOCKED_PROP_BASE_MAP.get(persist_key, True):
+                if TOPIC_LOCKED_PROP_BASE_MAP[persist_key]:
                     self.__dict__[persist_key] = value
 
         def __save(self):
             """
             Saves this topic object to persistent
+
+            NOTE: Will raise a KeyError of the lock map doesn't have the persist key in it
             """
             for persist_key, value in self.as_dict().iteritems():
-                if TOPIC_LOCKED_PROP_BASE_MAP.get(persist_key, True):
+                if TOPIC_LOCKED_PROP_BASE_MAP.get[persist_key]:
                     self.__persistent_db[self.label][persist_key] = value
 
         @staticmethod

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -19,6 +19,25 @@ init 0 python:
     TOPIC_TYPE_GREETING = "GREETING"
     TOPIC_TYPE_NORMAL = "NORMAL"
 
+    TOPIC_LOCKED_PROP_BASE_MAP = {
+        #Things which shouldn't change
+        "conditional": True,
+        "unlocked": True,
+        "nat_says": True,
+        "player_says": True,
+        "shown_count": True,
+        "last_seen": True,
+        "unlocked_on": True,
+
+        #Things which can change
+        "affinity_range": False,
+        "trust_range": False,
+        "category": False,
+        "prompt": False,
+        "location": False,
+        "additional_properties": False
+    }
+
     class Topic(object):
         """
         Topic class. Manages all topics
@@ -112,7 +131,8 @@ init 0 python:
             self.location = location
 
             #And finally, add this all back to the persistent dict
-            persistent_db[label] = self.as_dict()
+            persistent_db[label] = dict()
+            self.__save()
 
         def __eq__(self, other):
             """
@@ -166,17 +186,18 @@ init 0 python:
         def __load(self):
             """
             Internal load funtion
-
-            IN:
-                persist_data - the as_dict representation of this topic
             """
-            self.__dict__.update(self.__persistent_db[self.label])
+            for persist_key, value in self.__persistent_db[self.label].iteritems():
+                if TOPIC_LOCKED_PROP_BASE_MAP.get(persist_key, True):
+                    self.__dict__[persist_key] = value
 
         def __save(self):
             """
             Saves this topic object to persistent
             """
-            self.__persistent_db[self.label] = self.as_dict()
+            for persist_key, value in self.as_dict().iteritems():
+                if TOPIC_LOCKED_PROP_BASE_MAP.get(persist_key, True):
+                    self.__persistent_db[self.label][persist_key] = value
 
         @staticmethod
         def _save_topic_data():


### PR DESCRIPTION
Adds a map above the `Topic` class which stores info for saving/loading topics. The current one is a prefab which places out the properties which should be persisted and loaded with `True` and those which can be changed on the fly with `False`.

Those flagged with `False` are **not** persisted and will not be loaded after the fact.

For failsafe purposes, properties not listed will be considered as important and will be persisted, though I am considering just letting that raise a keyerror instead as realistically we should not be having properties that do not exist otherwise.

Thoughts?