### PR TITLE
Use Return Keys

### DIFF
--- a/game/script-farewells.rpy
+++ b/game/script-farewells.rpy
@@ -164,7 +164,7 @@ label farewell_love_you_mean_the_world_to_me:
     n "Y-{w=0.2}you know I'll miss you,{w=0.1} right?"
     n "Take care,{w=0.1} [player]!{w=0.2} You mean the world to me!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -188,7 +188,7 @@ label farewell_love_dont_like_saying_goodbye:
     n "I'll be okay!{w=0.2} Just come back soon,{w=0.1} alright?"
     n "Stay safe,{w=0.1} dummy!{w=0.2} I love you!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -212,7 +212,7 @@ label farewell_love_counting_on_you:
     $ chosen_endearment = random.choice(jn_globals.DEFAULT_PLAYER_ENDEARMENTS)
     n "Take care of yourself out there,{w=0.1} [chosen_endearment]!{w=0.2} I'm counting on you!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -237,7 +237,7 @@ label farewell_love_do_your_best:
     $ chosen_endearment = random.choice(jn_globals.DEFAULT_PLAYER_ENDEARMENTS)
     n "Do your best,{w=0.1} [chosen_endearment]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -263,7 +263,7 @@ label farewell_love_rooting_for_you:
     n "Well...{w=0.1} I'm rooting for you!"
     n "Make me proud,{w=0.1} [player]! I love you!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -287,7 +287,7 @@ label farewell_love_me_to_deal_with:
     n "You take care of yourself,{w=0.1} got it? Or you'll have me to deal with!"
     n "Bye now!{w=0.2} I love you!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -312,7 +312,7 @@ label farewell_love_wish_you_could_stay_forever:
     $ chosen_endearment = random.choice(jn_globals.DEFAULT_PLAYER_ENDEARMENTS)
     n "Goodbye,{w=0.1} [chosen_endearment]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 # AFFECTIONATE/ENAMORED farewells
 
@@ -339,7 +339,7 @@ label farewell_affectionate_enamored_was_having_fun:
     n "Well,{w=0.1} if you gotta go,{w=0.1} you gotta go!"
     n "Take care,{w=0.1} [player]!{w=0.2} Make me proud!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -364,7 +364,7 @@ label farewell_affectionate_enamored_waiting_for_you:
     n "I'll be waiting for you!"
     n "Goodbye,{w=0.1} [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -389,7 +389,7 @@ label farewell_affectionate_enamored_ill_be_okay:
     n "You better come back soon,{w=0.1} alright [player]?"
     n "Goodbye!{w=0.2} I'll miss you!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -414,7 +414,7 @@ label farewell_affectionate_enamored_dont_make_me_find_you:
     n "Come see me later,{w=0.1} promise?"
     n "Don't make me come find you!{w=0.2} Ehehe."
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -439,7 +439,7 @@ label farewell_affectionate_enamored_take_care_for_both:
     n "Take care of yourself,{w=0.1} [player]!{w=0.2} For both of us!"
     n "See you later!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -463,7 +463,7 @@ label farewell_affectionate_enamored_enjoy_our_time_together:
     n "You better be back later,{w=0.1} okay?{w=0.2} I really enjoy our time together."
     n "See you soon,{w=0.1} [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -486,7 +486,7 @@ label farewell_affectionate_enamored_see_me_soon:
     n "Doesn't mean I have to like it,{w=0.1} though..."
     n "Come see me soon,{w=0.1} okay?"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 # HAPPY/AFFECTIONATE farewells
 
@@ -509,7 +509,7 @@ init 5 python:
 label farewell_happy_affectionate_going_now:
     n "Going now,{w=0.1} [player]?{w=0.2} I'll see you later!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -531,7 +531,7 @@ label farewell_happy_affectionate_heading_off:
     n "Heading off now,{w=0.1} [player]?"
     n "Okay!{w=0.2} Take care!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -553,7 +553,7 @@ label farewell_happy_affectionate_stay_safe:
     n "Okaaay!{w=0.2} I'll be waiting for you!"
     n "Stay safe,{w=0.1} [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -575,7 +575,7 @@ label farewell_happy_affectionate_take_care:
     n "See you later,{w=0.1} [player]!"
     n "Take care out there!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -597,7 +597,7 @@ label farewell_happy_affectionate_see_me_soon:
     n "Goodbye,{w=0.1} [player]!"
     n "Come see me soon,{w=0.1} alright?"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 # NORMAL/HAPPY farewells
 
@@ -619,7 +619,7 @@ init 5 python:
 
 label farewell_normal_happy_see_you_later:
     n "See you later, [player]!"
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -640,7 +640,7 @@ init 5 python:
 label farewell_normal_happy_later:
     n "Later, [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -661,7 +661,7 @@ init 5 python:
 label farewell_normal_happy_goodbye:
     n "Goodbye, [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -682,7 +682,7 @@ init 5 python:
 label farewell_normal_happy_kay:
     n "'kay! Bye for now!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -703,7 +703,7 @@ init 5 python:
 label farewell_normal_happy_see_ya:
     n "See ya, [player]!"
     $ farewells.try_trust_dialogue()
-    jump _quit
+    return { "quit": None }
 
 # UPSET/DISTRESSED farewells
 init 5 python:
@@ -724,7 +724,7 @@ init 5 python:
 
 label farewell_upset_distressed_bye:
     n "Bye, [player]."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -744,7 +744,7 @@ init 5 python:
 
 label farewell_upset_distressed_later:
     n "Later, [player]."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -764,7 +764,7 @@ init 5 python:
 
 label farewell_upset_distressed_kay:
     n "'kay, [player]. Later."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -784,7 +784,7 @@ init 5 python:
 
 label farewell_upset_distressed_goodbye:
     n "Goodbye, [player]."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -804,7 +804,7 @@ init 5 python:
 
 label farewell_upset_distressed_see_you_around:
     n "See you around."
-    jump _quit
+    return { "quit": None }
 
 # DISTRESSED/BROKEN/RUINED farewells
 
@@ -826,7 +826,7 @@ init 5 python:
 
 label farewell_broken_ruined_yeah:
     n "Yeah."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -846,7 +846,7 @@ init 5 python:
 
 label farewell_broken_ruined_yep:
     n "Yep."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -866,7 +866,7 @@ init 5 python:
 
 label farewell_broken_ruined_uh_huh:
     n "Uh huh."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -886,7 +886,7 @@ init 5 python:
 
 label farewell_broken_ruined_nothing_to_say:
     n "..."
-    jump _quit
+    return { "quit": None }
 
 init 5 python:
     registerTopic(
@@ -906,7 +906,7 @@ init 5 python:
 
 label farewell_broken_ruined_kay:
     n "'kay."
-    jump _quit
+    return { "quit": None }
 
 # Farewells that allow the player to choose to stay
 
@@ -972,7 +972,7 @@ label farewell_short_session_ask:
                     n "Take care out there,{w=0.1} alright?"
                     n "See you later!"
                     $ farewells.try_trust_dialogue()
-                    jump _quit
+                    return { "quit": None }
 
         "Sorry, Natsuki. I really have to leave.":
             n "Nnnnnn-!"
@@ -981,7 +981,7 @@ label farewell_short_session_ask:
             n "Don't take too long,{w=0.1} alright?"
             n "See you later, [player]!"
             $ farewells.try_trust_dialogue()
-            jump _quit
+            return { "quit": None }
 
     return
 
@@ -1051,7 +1051,7 @@ label farewell_short_session_ask_alt:
             n "But you gotta make it up to me,{w=0.1} alright?"
             n "Stay safe,{w=0.1} [player]!{w=0.2} I'll see you later!"
             $ farewells.try_trust_dialogue()
-            jump _quit
+            return { "quit": None }
     return
 
 # Natsuki tries to confidently ask her player to stay
@@ -1093,7 +1093,7 @@ label farewell_fake_confidence_ask:
             n "I'll see you later then,{w=0.1} [player]!"
             n "Don't keep me waiting,{w=0.1} alright?"
             $ farewells.try_trust_dialogue()
-            jump _quit
+            return { "quit": None }
     return
 
 # Natuski really doesn't want to be alone today; she pleads for her player to stay
@@ -1137,7 +1137,7 @@ label farewell_pleading_ask:
             n "Or you'll have to make it up to me...{w=0.3} ahaha..."
             n "Stay safe,{w=0.1} [player]!"
             $ farewells.try_trust_dialogue()
-            jump _quit
+            return { "quit": None }
     return
 
 # Natsuki gently asks her player to stay
@@ -1181,7 +1181,7 @@ label farewell_gentle_ask:
             n "I-I love you,{w=0.1} [player]..."
             n "I'll see you later."
             $ farewells.try_trust_dialogue()
-            jump _quit
+            return { "quit": None }
     return
 
 # Trust dialogue; chance to call upon farewell completing and prior to the game closing
@@ -1240,6 +1240,8 @@ label farewell_extra_trust:
         n "Um...{w=0.3} I think you messed up somewhere,{w=0.1} [player]...{w=0.3} Aha..."
         n "Bye now! Good luck fixing it!"
 
+    return { "quit": None }
+
 # Fallback farewell if selecting a farewell fails
 
 init 5 python:
@@ -1255,4 +1257,4 @@ init 5 python:
 
 label farewell_fallback_see_you_soon:
     n "Alright, see you soon."
-    $ renpy.quit()
+    return { "quit": None }


### PR DESCRIPTION
We have a return key for `"quit"` which jumps to the user-defined `"quit"` label, allowing us to run some exit flow code automatically.

This PR makes farewells use this return key.