### PR TITLE
[FEATURE] copypasting for Renpy's Input

### DIFF
--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -1,8 +1,10 @@
 # Original Paste code and Sub-Selections v2 by LegendKiller21
 # Copy, Cut, Select All, and Original Markers for Sub-Selections and Sub-Selections v2 optimizations by LordBaaa
 #
-# Although heavily editted, original by LegendKiller21 and LordBaaa as mentioned above
+# Although this is heavily edited, original by LegendKiller21 and LordBaaa as mentioned above
 # original - https://github.com/Legendkiller21/MAS-Submods-Paste
+
+
 init 1 python:
     config.keymap['input_paste'] = ['ctrl_K_v']
     config.keymap['input_copy'] = ['ctrl_K_c']
@@ -13,12 +15,14 @@ init 1 python:
     config.keymap['input_move_select_home'] = ['ctrl_K_HOME']
     config.keymap['input_move_select_end'] = ['ctrl_K_END']
 
-init 999 python:
+init 999 python in Input_overwrite:
     import pygame
-
     pygame.scrap.init()
-    #no idea why but pygame.scrap.get_init apparently doesn't exist... is renpy's pygame that outdated?
 
+    # select_start_pos - does not change while selecting, set on selection start
+    #  if is None -> nothing is selected
+    # select_end_pos - moves about
+    # select_last_end_pos - updated on selection render
     setattr(renpy.display.behavior.Input, 'select_start_pos', None)
     setattr(renpy.display.behavior.Input, 'select_end_pos', 0)
     setattr(renpy.display.behavior.Input, 'select_last_end_pos', 0)
@@ -26,48 +30,74 @@ init 999 python:
     setattr(renpy.display.behavior.Input, 'select_end_char', "\u231F")
 
     def get_selected(self):
+        """
+            returns selected text
+        """
+        # we return an empty string instead of None so nothing breaks even if it's called when it shouldn't
         if self.select_start_pos is None:
             return ""
 
-        mark1_pos = self.select_start_pos
-        mark2_pos = self.select_end_pos
-
-        if mark1_pos > mark2_pos:
-            mark1_pos, mark2_pos = mark2_pos, mark1_pos
+        # Order positions for string indexing
+        mark1_pos = min(self.select_start_pos, self.select_end_pos)
+        mark2_pos = max(self.select_start_pos, self.select_end_pos)
 
         selected = self.content[mark1_pos+1:mark2_pos+1]
 
         return selected
 
     def remove_selected(self):
+        """
+            removes selected text and also returns it
+        """
+        # nothing is selected so we return right away
         if self.select_start_pos is None:
             return
 
-        mark1_pos = self.select_start_pos
-        mark2_pos = self.select_end_pos
-
-        if mark1_pos > mark2_pos:
-            mark1_pos, mark2_pos = mark2_pos, mark1_pos
+        # Order positions for string indexing
+        mark1_pos = min(self.select_start_pos, self.select_end_pos)
+        mark2_pos = max(self.select_start_pos, self.select_end_pos)
 
         selected = self.get_selected()
-        wo_selected = self.content[:mark1_pos+1]+self.content[mark2_pos+1:]
-        self.content = wo_selected
-        self.caret_pos -= len(selected)-2
 
+        # get content without selected text
+        # still contains selection delimiters
+        wo_selected = self.content[:mark1_pos+1]+self.content[mark2_pos+1:]
+
+        # remove selected text from content
+        self.content = wo_selected
+
+        # adjust caret accordingly
+        self.caret_pos = mark1_pos
+
+        # finally remove delimiters and call `update_text()`
         self.remove_selected_markers()
 
         return selected
 
     def selected_copy(self):
-        pygame.scrap.put(pygame.SCRAP_TEXT,self.get_selected())
+        """
+            store selected text into clipboard
+            if nothing is selected, empty string is stored
+        """
+        # If there is nothing selected, return
+        if self.select_start_pos is None:
+            return
+
+        selected = self.get_selected()
+        pygame.scrap.put(pygame.SCRAP_TEXT,selected)
 
     def selected_cut(self):
+        """
+            stores selected text and also removes it
+        """
         cut = self.remove_selected()
         pygame.scrap.put(pygame.SCRAP_TEXT,cut)
-        #self.remove_selected_markers()
-        #self.update_text(self.content, self.editable, check_size = True)
 
     def input_paste(self):
+        """
+            pastes text from clipboard to current caret pos
+            only if it contains only allowed characters and no excluded chars
+        """
         paste = pygame.scrap.get(pygame.SCRAP_TEXT)
 
         # Check if text we're trying to paste contains only allowed characters
@@ -77,116 +107,177 @@ init 999 python:
             if self.exclude and char in self.exclude:
                 return
 
+        # insert at caret pos
         self.content = self.content[:self.caret_pos]+paste+self.content[self.caret_pos:]
+
+        # put caret at end of pasted string
         self.caret_pos += len(paste)
 
+        # update_text
         self.update_text(self.content, self.editable, check_size = True)
 
     def move_selected_left(self):
-        global testytest
+        """
+            moves select_end_pos left
+        """
+
+        # check if we are starting a new selection
         if self.select_start_pos is None:
+
+            # make sure we don't go into negative indices
             if self.caret_pos <= 0:
                 return
 
+            # set both delimiters at caret
             self.select_start_pos = self.caret_pos
             self.select_end_pos = self.caret_pos
 
+        # stop at index 0
         if self.select_end_pos <= 0:
             return
 
+        # all checks done, move select_end_pos to the left together with the caret
         self.select_end_pos -= 1
         self.caret_pos = self.select_end_pos
 
-        testytest = self.select_end_pos
-
     def move_selected_right(self):
+        """
+            moves select_end_pos right
+            works exactly as `move_select_left` except it moves it right >.>
+        """
+        # get lenght of content without delimiters
+        length = len(get_content_wo_markers(self))
+
         if self.select_start_pos is None:
-            if self.caret_pos >= len(get_content_wo_markers(self)):
+            if self.caret_pos >= length:
                 return
 
             self.select_start_pos = self.caret_pos
             self.select_end_pos = self.caret_pos
 
-        if self.select_end_pos >= len(get_content_wo_markers(self)):
+        if self.select_end_pos >= length:
             return
 
         self.select_end_pos += 1
         self.caret_pos = self.select_end_pos+1
 
     def move_selected_home(self):
+        """
+            selects text between current caret pos to the beginning
+        """
+        # make sure there is something to select
         if self.caret_pos <= 0:
             return
 
+        # if nothing's selected currently, set starting delimiter at caret pos
         if self.select_start_pos is None:
             self.select_start_pos = self.caret_pos
 
+        # move ending delimiter and caret at the start
         self.select_end_pos = 0
         self.caret_pos = self.select_end_pos
 
     def move_selected_end(self):
-        no_markers = get_content_wo_markers(self)
+        """
+            selects text between current caret pos to the end of the text
+            works almost exactly the same as `move_select_home`
+        """
+        # get lenght of content without delimiters
+        length = len(get_content_wo_markers(self))
 
-        if self.caret_pos >= len(no_markers):
+        if self.caret_pos >= length:
             return
 
         if self.select_start_pos is None:
             self.select_start_pos = self.caret_pos
 
-        self.select_end_pos = len(no_markers)
+        self.select_end_pos = length
         self.caret_pos = self.select_end_pos
 
     def move_selected_all(self):
-        no_markers = get_content_wo_markers(self)
-        if len(self.content)<=0:
+        """
+            selects all text
+        """
+
+        # get lenght of content without delimiters
+        length = len(get_content_wo_markers(self))
+
+        # check if there is anything to select
+        if length <= 0:
             return
 
+        # start selection at the beginning
         self.select_start_pos = 0
 
-        self.select_end_pos = len(no_markers)
+        # end at the end
+        self.select_end_pos = length
 
     def render_selected_markers(self):
+        """
+            inserts delimiters into text and calls `update_text`
+        """
+
+        # check if selection has at all changed
         if self.select_end_pos == self.select_last_end_pos:
             return
+        # selection has changed, update select_last_end_pos
         self.select_last_end_pos = self.select_end_pos
 
+        # content without delimiters
         text_wo_markers = get_content_wo_markers(self)
 
+        # select_start_pos is None so remove delimiters
         if self.select_start_pos is None:
             self.update_text(text_wo_markers, self.editable, check_size = True)
+            return
 
-        mark1_pos = self.select_start_pos
-        mark2_pos = self.select_end_pos
+        # Order positions for string indexing
+        mark1_pos = min(self.select_start_pos, self.select_end_pos)
+        mark2_pos = max(self.select_start_pos, self.select_end_pos)
 
-        if mark1_pos > mark2_pos:
-            mark1_pos, mark2_pos = mark2_pos, mark1_pos
-
+        # insert delimiters into text
         text_w_markers = text_wo_markers[:mark1_pos]+"\u231C"+text_wo_markers[mark1_pos:mark2_pos]+"\u231F"+text_wo_markers[mark2_pos:]
 
+        # update text
         self.update_text(text_w_markers, self.editable, check_size = True)
 
     def get_content_wo_markers(self):
+        """
+            returns content without delimiters
+        """
+        # If nothing is selected, return empty string
+        if self.select_start_pos is None:
+            return self.content
+
+        # return content without delimiters
+        #NOTE: does not change self.content
         return self.content.replace(self.select_start_char, '').replace(self.select_end_char, '')
 
     def remove_selected_markers(self):
+        """
+            removes delimiters from content
+        """
+
+        # If nothing's selected, return
         if self.select_start_pos is None:
             return
 
+        # remove delimiters from content
         self.content = get_content_wo_markers(self)
-        self.caret_pos = min(self.select_start_pos, self.select_end_pos)
+
+        # make sure caret isn't outside of text bounds now that we've removed delimiters, essentially 2 characters
+        length = len(self.content)
+        self.caret_pos = min(length, self.select_end_pos)
+
+        # reset selection values
         self.select_start_pos = None
         self.select_last_end_pos = None
+
+        # update text
         self.update_text(self.content, self.editable, check_size = True)
 
-    def caret_relative2markers(self):
-        pos = 0
-        if self.select_start_pos < self.caret_pos:
-            pos += 1
 
-        if self.select_end_pos < self.caret_pos:
-            pos += 1
-
-        return pos
-
+    # Add new functions to the Input class
     setattr(renpy.display.behavior.Input, 'move_selected_left', move_selected_left)
     setattr(renpy.display.behavior.Input, 'move_selected_right', move_selected_right)
     setattr(renpy.display.behavior.Input, 'move_selected_home', move_selected_home)
@@ -202,6 +293,7 @@ init 999 python:
 
     map_event = renpy.display.behavior.map_event
 
+    # event function overwrite
     def event_ov(self, ev, x, y, st):
         self.old_caret_pos = self.caret_pos
 
@@ -213,9 +305,11 @@ init 999 python:
         raw_text = None
 
         if map_event(ev, "input_backspace"):
+            # if something is selected, remove it
             if self.select_start_pos is not None:
                 self.remove_selected()
 
+            # if not, do normal backspace stuff
             elif self.content and self.caret_pos > 0:
                 content = self.content[0:self.caret_pos-1] + self.content[self.caret_pos:l]
                 self.caret_pos -= 1
@@ -225,6 +319,7 @@ init 999 python:
             raise renpy.display.core.IgnoreEvent()
 
         elif map_event(ev, "input_enter"):
+            # remove delimiters from text because we are "submiting" it
             self.remove_selected_markers()
 
             content = self.content
@@ -239,9 +334,11 @@ init 999 python:
                 return content
 
         elif map_event(ev, "input_left"):
+            # if something's selected, cancel selectiong
             if self.select_start_pos is not None:
                 self.remove_selected_markers()
 
+            # otherwise move caret left
             elif self.caret_pos > 0:
                 self.caret_pos -= 1
                 self.update_text(self.content, self.editable)
@@ -250,6 +347,7 @@ init 999 python:
             raise renpy.display.core.IgnoreEvent()
 
         elif map_event(ev, "input_right"):
+            # same as left
             if self.select_start_pos is not None:
                 self.remove_selected_markers()
 
@@ -261,9 +359,12 @@ init 999 python:
             raise renpy.display.core.IgnoreEvent()
 
         elif map_event(ev, "input_delete"):
-            self.remove_selected_markers()
+            # same as backspace, but delete
 
-            if self.caret_pos < l:
+            if self.select_start_pos is not None:
+                self.remove_selected()
+
+            elif self.caret_pos < l:
                 content = self.content[0:self.caret_pos] + self.content[self.caret_pos+1:l]
                 self.update_text(content, self.editable)
 
@@ -282,6 +383,7 @@ init 999 python:
             renpy.display.render.redraw(self, 0)
             raise renpy.display.core.IgnoreEvent()
 
+        # (almost) all logic handled inside funcions, no need for explaining all of them
         elif map_event(ev, "input_select_all"):
             self.move_selected_all()
 
@@ -304,9 +406,11 @@ init 999 python:
             self.selected_cut()
 
         elif map_event(ev, "input_paste"):
+            # if something is selected, remove it
             if self.select_start_pos is not None:
                 self.remove_selected()
 
+            # paste at caret pos
             self.input_paste()
 
         elif ev.type == pygame.TEXTEDITING:
@@ -343,6 +447,7 @@ init 999 python:
                 text = text[:remaining]
 
             if text:
+                # if something's typed, cancel selection
                 if self.select_start_pos is not None:
                     self.remove_selected()
 
@@ -353,7 +458,11 @@ init 999 python:
 
             raise renpy.display.core.IgnoreEvent()
 
+        # if something is selected, call delimiter render function
         if self.select_start_pos is not None:
             self.render_selected_markers()
+        else:
+            self.remove_selected_markers()
 
+    # overwrite original event function with our event_ov
     setattr(renpy.display.behavior.Input, 'event', event_ov)

--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -1,6 +1,8 @@
 # Original Paste code and Sub-Selections v2 by LegendKiller21
 # Copy, Cut, Select All, and Original Markers for Sub-Selections and Sub-Selections v2 optimizations by LordBaaa
-
+#
+# Although heavily editted, original by LegendKiller21 and LordBaaa as mentioned above
+# original - https://github.com/Legendkiller21/MAS-Submods-Paste
 init 1 python:
     config.keymap['input_paste'] = ['ctrl_K_v']
     config.keymap['input_copy'] = ['ctrl_K_c']
@@ -23,23 +25,51 @@ init 999 python:
     setattr(renpy.display.behavior.Input, 'select_end_char', "\u231F")
 
     def get_selected(self):
-        start_pos = self.select_start_pos
-        end_pos = self.select_end_pos
-
-        if not(start_pos and end_pos):
+        if self.select_start_pos is None:
             return ""
 
+        mark1_pos = self.select_start_pos
+        mark2_pos = self.select_end_pos
 
-        if start_pos == end_pos:
-            selected = ""
+        if mark1_pos > mark2_pos:
+            mark1_pos, mark2_pos = mark2_pos, mark1_pos
 
-        elif start_pos > end_pos:
-            selected = self.content[end_pos:start_pos]
-
-        elif start_pos < end_pos:
-            selected = self.content[start_pos:end_pos]
+        selected = self.content[mark1_pos+1:mark2_pos+1]
 
         return selected
+
+    def remove_selected(self):
+        if self.select_start_pos is None:
+            return
+
+        mark1_pos = self.select_start_pos
+        mark2_pos = self.select_end_pos
+
+        if mark1_pos > mark2_pos:
+            mark1_pos, mark2_pos = mark2_pos, mark1_pos
+
+        selected = self.get_selected()
+        wo_selected = self.content[:mark1_pos+1]+self.content[mark2_pos+1:]
+        self.content = wo_selected
+        self.caret_pos -= mark1_pos-mark2_pos-2
+        self.select_start_pos = None
+        return selected
+
+    def selected_copy(self):
+        pygame.scrap.put(pygame.SCRAP_TEXT,self.get_selected())
+
+    def selected_cut(self):
+        cut = self.remove_selected()
+        pygame.scrap.put(pygame.SCRAP_TEXT,cut)
+
+        self.update_text(self.content, self.editable, check_size = True)
+
+    def input_paste(self):
+        paste = pygame.scrap.get(pygame.SCRAP_TEXT)
+        self.content = self.content[:self.caret_pos]+paste+self.content[self.caret_pos:]
+        self.caret_pos += len(paste)
+
+        self.update_text(self.content, self.editable, check_size = True)
 
     def move_selected_left(self):
         if self.select_start_pos is None:
@@ -80,14 +110,26 @@ init 999 python:
         self.caret_pos = self.select_end_pos
 
     def move_selected_end(self):
-        if self.caret_pos >= len(get_content_wo_markers(self)):
+        no_markers = get_content_wo_markers(self)
+
+        if self.caret_pos >= len(no_markers):
             return
 
         if self.select_start_pos is None:
             self.select_start_pos = self.caret_pos
 
-        self.select_end_pos = len(get_content_wo_markers(self))
+        self.select_end_pos = len(no_markers)
         self.caret_pos = self.select_end_pos
+
+    def move_selected_all(self):
+        no_markers = get_content_wo_markers(self)
+        if len(self.content)<=0:
+            return
+
+        if self.select_start_pos is None:
+            self.select_start_pos = 0
+
+        self.select_end_pos = len(no_markers)
 
     def render_selected_markers(self):
         text_wo_markers = get_content_wo_markers(self)
@@ -105,7 +147,9 @@ init 999 python:
 
         self.update_text(text_w_markers, self.editable, check_size = True)
 
-    def get_content_wo_markers(self):#FIXME:pls, my brain mush from this
+    def get_content_wo_markers(self):
+        """
+        #TODO: make this work
         if self.select_start_pos is None:
             return self.content
 
@@ -116,6 +160,9 @@ init 999 python:
             mark1_pos, mark2_pos = mark2_pos, mark1_pos
 
         return self.content[:mark1_pos]+self.content[mark1_pos+1:mark2_pos+1]+self.content[mark2_pos+2:]
+        """
+
+        return self.content.replace(self.select_start_char, '').replace(self.select_end_char, '')
 
     def remove_selected_markers(self):
         if self.select_start_pos is None:
@@ -141,6 +188,12 @@ init 999 python:
     setattr(renpy.display.behavior.Input, 'move_selected_end', move_selected_end)
     setattr(renpy.display.behavior.Input, 'render_selected_markers', render_selected_markers)
     setattr(renpy.display.behavior.Input, 'remove_selected_markers', remove_selected_markers)
+    setattr(renpy.display.behavior.Input, 'move_selected_all', move_selected_all)
+    setattr(renpy.display.behavior.Input, 'selected_copy', selected_copy)
+    setattr(renpy.display.behavior.Input, 'selected_cut', selected_cut)
+    setattr(renpy.display.behavior.Input, 'input_paste', input_paste)
+    setattr(renpy.display.behavior.Input, 'get_selected', get_selected)
+    setattr(renpy.display.behavior.Input, 'remove_selected', remove_selected)
 
     map_event = renpy.display.behavior.map_event
 
@@ -217,6 +270,9 @@ init 999 python:
             renpy.display.render.redraw(self, 0)
             raise renpy.display.core.IgnoreEvent()
 
+        elif map_event(ev, "input_select_all"):
+            self.move_selected_all()
+
         elif map_event(ev, "input_move_select_left"):
             self.move_selected_left()
 
@@ -230,7 +286,13 @@ init 999 python:
             self.move_selected_end()
 
         elif map_event(ev, "input_copy"):
-            pass
+            self.selected_copy()
+
+        elif map_event(ev, "input_cut"):
+            self.selected_cut()
+
+        elif map_event(ev, "input_paste"):
+            self.input_paste()
 
         elif ev.type == pygame.TEXTEDITING:
             self.update_text(self.content, self.editable, check_size=True)
@@ -242,7 +304,7 @@ init 999 python:
             raw_text = ev.text
 
         elif ev.type == pygame.KEYDOWN:
-            self.remove_selected_markers()
+            #self.remove_selected_markers()
 
             if ev.unicode and ord(ev.unicode[0]) >= 32:
                 raw_text = ev.unicode

--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -231,7 +231,10 @@ init 999 python:
                 return content
 
         elif map_event(ev, "input_left"):
-            if self.caret_pos > 0:
+            if self.select_start_pos is not None:
+                self.remove_selected_markers()
+
+            elif self.caret_pos > 0:
                 self.caret_pos -= 1
                 self.update_text(self.content, self.editable)
 
@@ -239,7 +242,10 @@ init 999 python:
             raise renpy.display.core.IgnoreEvent()
 
         elif map_event(ev, "input_right"):
-            if self.caret_pos < l:
+            if self.select_start_pos is not None:
+                self.remove_selected_markers()
+
+            elif self.caret_pos < l:
                 self.caret_pos += 1
                 self.update_text(self.content, self.editable)
 
@@ -290,6 +296,9 @@ init 999 python:
             self.selected_cut()
 
         elif map_event(ev, "input_paste"):
+            if self.select_start_pos is not None:
+                self.remove_selected()
+
             self.input_paste()
 
         elif ev.type == pygame.TEXTEDITING:
@@ -302,9 +311,6 @@ init 999 python:
             raw_text = ev.text
 
         elif ev.type == pygame.KEYDOWN:
-            #if ev.key != pygame.KMOD_CTRL and self.select_start_pos:
-            #    self.caret_pos = min(self.select_end_pos, self.select_start_pos)
-            #    self.remove_selected()
 
             if ev.unicode and ord(ev.unicode[0]) >= 32:
                 raw_text = ev.unicode

--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -69,6 +69,14 @@ init 999 python:
 
     def input_paste(self):
         paste = pygame.scrap.get(pygame.SCRAP_TEXT)
+
+        # Check if text we're trying to paste contains only allowed characters
+        for char in paste:
+            if self.allow and char not in self.allow:
+                return
+            if self.exclude and char in self.exclude:
+                return
+
         self.content = self.content[:self.caret_pos]+paste+self.content[self.caret_pos:]
         self.caret_pos += len(paste)
 

--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -15,10 +15,11 @@ init 1 python:
     config.keymap['input_move_select_home'] = ['ctrl_K_HOME']
     config.keymap['input_move_select_end'] = ['ctrl_K_END']
 
-init 999 python in Input_overwrite:
+init 999 python in jn_input_overwrite:
     import pygame
     pygame.scrap.init()
 
+    ## Add some new vars
     # select_start_pos - does not change while selecting, set on selection start
     #  if is None -> nothing is selected
     # select_end_pos - moves about
@@ -277,7 +278,7 @@ init 999 python in Input_overwrite:
         self.update_text(self.content, self.editable, check_size = True)
 
 
-    # Add new functions to the Input class
+    # Add new methods to the Input class
     setattr(renpy.display.behavior.Input, 'move_selected_left', move_selected_left)
     setattr(renpy.display.behavior.Input, 'move_selected_right', move_selected_right)
     setattr(renpy.display.behavior.Input, 'move_selected_home', move_selected_home)
@@ -291,10 +292,14 @@ init 999 python in Input_overwrite:
     setattr(renpy.display.behavior.Input, 'get_selected', get_selected)
     setattr(renpy.display.behavior.Input, 'remove_selected', remove_selected)
 
+    # renpy's function for detecting and processing keyboard events
     map_event = renpy.display.behavior.map_event
 
-    # event function overwrite
+    # `event` overwrite
     def event_ov(self, ev, x, y, st):
+        """
+            editted renpy's `event` method
+        """
         self.old_caret_pos = self.caret_pos
 
         if not self.editable:

--- a/game/input_additions.rpy
+++ b/game/input_additions.rpy
@@ -1,0 +1,232 @@
+# Original Paste code and Sub-Selections v2 by LegendKiller21
+# Copy, Cut, Select All, and Original Markers for Sub-Selections and Sub-Selections v2 optimizations by LordBaaa
+
+init 1 python:
+    config.keymap['input_paste'] = ['ctrl_K_v']
+    config.keymap['input_copy'] = ['ctrl_K_c']
+    config.keymap['input_cut'] = ['ctrl_K_x']
+    config.keymap['input_select_all'] = ['ctrl_K_a']
+    config.keymap['input_move_select_left'] = ['ctrl_K_LEFT', 'ctrl_repeat_K_LEFT']
+    config.keymap['input_move_select_right'] = ['ctrl_K_RIGHT', 'ctrl_repeat_K_RIGHT']
+
+init 999 python:
+    import pygame
+
+    setattr(renpy.display.behavior.Input, 'select_start_pos', None)
+    setattr(renpy.display.behavior.Input, 'select_end_pos', 0)
+    setattr(renpy.display.behavior.Input, 'select_start_char', "\u231C")
+    setattr(renpy.display.behavior.Input, 'select_end_char', "\u231F")
+
+    def get_selected(self):
+        start_pos = self.select_start_pos
+        end_pos = self.select_end_pos
+
+        if not(start_pos and end_pos):
+            return ""
+
+
+        if start_pos == end_pos:
+            selected = ""
+
+        elif start_pos > end_pos:
+            selected = self.content[end_pos:start_pos]
+
+        elif start_pos < end_pos:
+            selected = self.content[start_pos:end_pos]
+
+        return selected
+
+    def move_selected_left(self):
+        if self.select_start_pos is None:
+            self.select_start_pos = self.caret_pos
+            self.select_end_pos = self.caret_pos
+
+        if self.select_end_pos <= 0:
+            return
+        self.select_end_pos -= 1
+
+    def move_selected_right(self):
+        if self.select_start_pos is None:
+            self.select_start_pos = self.caret_pos
+            self.select_end_pos = self.caret_pos
+
+        if self.select_end_pos >= len(self.content)-2:
+            return
+        self.select_end_pos += 1
+
+    def render_selected_markers(self):
+        text_wo_markers = get_content_wo_markers(self) #DEBUG:
+
+        if self.select_start_pos is None:
+            self.update_text(text_wo_markers, self.editable, check_size = True)
+
+        mark1_pos = self.select_start_pos
+        mark2_pos = self.select_end_pos
+
+        if mark1_pos > mark2_pos:
+            mark1_pos, mark2_pos = mark2_pos, mark1_pos
+
+        text_w_markers = text_wo_markers[:mark1_pos]+"\u231C"+text_wo_markers[mark1_pos:mark2_pos]+"\u231F"+text_wo_markers[mark2_pos:]
+
+        self.update_text(text_w_markers, self.editable, check_size = True)
+
+    def get_content_wo_markers(self):
+        content = self.content
+        content = content.replace("\u231C", '')
+        content = content.replace("\u231F", '')
+
+        return content
+
+
+    setattr(renpy.display.behavior.Input, 'move_selected_left', move_selected_left)
+    setattr(renpy.display.behavior.Input, 'move_selected_right', move_selected_right)
+    setattr(renpy.display.behavior.Input, 'render_selected_markers', render_selected_markers)
+
+    map_event = renpy.display.behavior.map_event
+
+    def event_ov(self, ev, x, y, st):
+        self.old_caret_pos = self.caret_pos
+
+        if not self.editable:
+            return None
+
+        l = len(self.content)
+
+        raw_text = None
+
+        if map_event(ev, "input_backspace"):
+
+            if self.content and self.caret_pos > 0:
+                content = self.content[0:self.caret_pos-1] + self.content[self.caret_pos:l]
+                self.caret_pos -= 1
+                self.update_text(content, self.editable)
+
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_enter"):
+
+            content = self.content
+
+            if self.edit_text:
+                content = content[0:self.caret_pos] + self.edit_text + self.content[self.caret_pos:]
+
+            if self.value:
+                return self.value.enter()
+
+            if not self.changed:
+                return content
+
+        elif map_event(ev, "input_left"):
+            if self.caret_pos > 0:
+                self.caret_pos -= 1
+                self.update_text(self.content, self.editable)
+
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_right"):
+            if self.caret_pos < l:
+                self.caret_pos += 1
+                self.update_text(self.content, self.editable)
+
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_delete"):
+            if self.caret_pos < l:
+                content = self.content[0:self.caret_pos] + self.content[self.caret_pos+1:l]
+                self.update_text(content, self.editable)
+
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_home"):
+            self.caret_pos = 0
+            self.update_text(self.content, self.editable)
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_end"):
+            self.caret_pos = l
+            self.update_text(self.content, self.editable)
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+        elif map_event(ev, "input_move_select_left"):
+            self.move_selected_left()
+            self.render_selected_markers()
+
+        elif map_event(ev, "input_move_select_right"):
+            self.move_selected_right()
+            self.render_selected_markers()
+
+        elif ev.type == pygame.TEXTEDITING:
+            self.update_text(self.content, self.editable, check_size=True)
+
+            raise renpy.display.core.IgnoreEvent()
+
+        elif ev.type == pygame.TEXTINPUT:
+            self.edit_text = ""
+            raw_text = ev.text
+
+        elif ev.type == pygame.KEYDOWN:
+            if ev.unicode and ord(ev.unicode[0]) >= 32:
+                raw_text = ev.unicode
+            elif renpy.display.interface.text_event_in_queue():
+                raw_text = ''
+
+        if raw_text is not None:
+
+            text = ""
+
+            for c in raw_text:
+
+                if self.allow and c not in self.allow:
+                    continue
+                if self.exclude and c in self.exclude:
+                    continue
+
+                text += c
+
+            if self.length:
+                remaining = self.length - len(self.content)
+                text = text[:remaining]
+
+            if text:
+
+                content = self.content[0:self.caret_pos] + text + self.content[self.caret_pos:l]
+                self.caret_pos += len(text)
+
+                self.update_text(content, self.editable, check_size=True)
+
+            raise renpy.display.core.IgnoreEvent()
+
+            if self.content and self.caret_pos < l:
+                if (
+                    (self.start_marker_pos == 0 and self.caret_pos != self.start_marker_pos)
+                    or (self.end_marker_pos == l and self.caret_pos != self.end_marker_pos-1)
+                    or (self.caret_pos != self.start_marker_pos and self.caret_pos != self.end_marker_pos)
+                    or not (self.start_marker_is_set and self.end_marker_is_set)
+                ):
+                    content = self.content[0:self.caret_pos] + self.content[self.caret_pos+1:l]
+                    if self.start_marker_pos < self.caret_pos <= self.end_marker_pos:
+                        self.end_marker_pos -=1
+                    elif self.caret_pos < self.start_marker_pos:
+                        self.start_marker_pos -=1
+                        self.end_marker_pos -=1
+
+                    self.update_text(content, self.editable)
+
+                    if self.start_marker_pos == self.end_marker_pos-1:
+                        content = list(self.remove_marker_text(self.content))
+                        self.reset_marker_values()
+                        self.caret_pos -= 1
+                        content = "".join(content)
+                        self.update_text(content, self.editable)
+
+            renpy.display.render.redraw(self, 0)
+            raise renpy.display.core.IgnoreEvent()
+
+
+    setattr(renpy.display.behavior.Input, 'event', event_ov)


### PR DESCRIPTION
This introduces the following
- `Ctrl+C` copy
- `Ctrl+V` paste
- `Ctrl+X` cut
- `Ctrl+A` select all
- `Ctrl+Home` select from caret to beginning of text
- `Ctrl+End` select from caret to end of text
- `Ctrl+left` move selection left
- `Ctrl+right` move selection right

  this follows Input's allowed and excluded characters, as well as max length