### PR TITLE
Fixed custom music crash

### DIFF
--- a/game/custom-music.rpy
+++ b/game/custom-music.rpy
@@ -63,7 +63,7 @@ init python in jn_custom_music:
     # Tracks what is currently playing to avoid repetition with random music picks
     _now_playing = None
 
-    def __get_directory_exists():
+    def get_directory_exists():
         """
         Checks to see if the custom_music directory exists, and creates it if not
         Returns True/False based on whether the directory already existed
@@ -105,7 +105,7 @@ label music_menu:
     python:
         success = False
 
-        if jn_custom_music.__get_directory_exists():
+        if jn_custom_music.get_directory_exists():
 
             # Get the user's music, then sort the options for presentation
             custom_music_options = jn_custom_music.get_all_custom_music()

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -4206,7 +4206,7 @@ label talk_custom_music_explanation:
         n 1nchbg "Let me just take a look,{w=0.1} one sec..."
         n 1ncssr "..."
 
-    if jn_custom_music.__get_directory_exists():
+    if jn_custom_music.get_directory_exists():
         n 1tnmbg "Well,{w=0.1} hey!{w=0.2} It's already there!{w=0.2} I must have set it up earlier and forgot."
         n 1uchgn "No complaints from me!"
 


### PR DESCRIPTION
get_directory_exists was used outside of the custom-music script; should not have been private.

closes #149 