### PR TITLE
Data Migration Framework

### DIFF
--- a/game/options.rpy
+++ b/game/options.rpy
@@ -13,7 +13,7 @@
 ## The _() surrounding the string marks it as eligible for translation.
 
 define config.name = "Just Natsuki"
-
+define config.window_title = _("Just Natsuki - BETA")
 
 ## Determines if the title given above is shown on the main menu screen. Set
 ## this to False to hide the title.
@@ -23,7 +23,7 @@ define gui.show_name = False
 
 ## The version of the game.
 
-define config.version = "4.1.0"
+define config.version = "0.0.1"
 
 
 ## Text that is placed on the game's about screen. To insert a blank line

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -23,7 +23,7 @@ define gui.show_name = False
 
 ## The version of the game.
 
-define config.version = "0.0.1"
+define config.version = "0.0.2"
 
 
 ## Text that is placed on the game's about screen. To insert a blank line

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -1270,7 +1270,7 @@ screen preferences():
     text "v[config.version]":
                 xalign 1.0 yalign 1.0
                 xoffset -10 yoffset -10
-                style "main_menu_version"
+                style "default"
 
 style pref_label is gui_label
 style pref_label_text is gui_label_text

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -27,6 +27,12 @@ label ch30_init:
     python:
         import random
 
+        #Run runtime data migrations here
+        jn_data_migrations.runRuntimeMigrations()
+
+        #Now adjust the stored version number
+        persistent._jn_version = config.version
+
         # Check the daily affinity cap and reset if need be
         Natsuki.check_reset_daily_affinity_gain()
 

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -124,7 +124,7 @@ python early in jn_data_migrations:
                 LATE_UPDATES.append(UPDATE_FUNCS[store.persistent._jn_version][MigrationRuntimes.RUNTIME])
 
             #We're below the latest version, so we need to migrate to the next one in the chain
-            _callable, from_version = UPDATE_FUNCS[from_version][MigrationRuntimes.RUNTIME]
+            _callable, from_version = UPDATE_FUNCS[from_version][MigrationRuntimes.INIT]
 
             #Migrate
             _callable()
@@ -143,8 +143,15 @@ init 10 python:
 
 #All migration scripts go here
 init python in jn_data_migrations:
+    DID_DO_UPDATE = False
+
     #This runs a migration from version 0.0.0 to 0.0.1
     #This script serves an example and hence, does nothing. All arguments are present however "runtime" is not necessary
     @migration(["0.0.0"], "0.0.1", runtime=MigrationRuntimes.INIT)
     def to_0_0_1():
         pass
+
+    @migration(["0.0.1"], "0.0.2")
+    def to_0_0_2():
+        global DID_DO_UPDATE
+        DID_DO_UPDATE = True

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -113,16 +113,18 @@ python early in jn_data_migrations:
         if store.persistent._jn_version not in UPDATE_FUNCS:
             return
 
-        #Set to_version to the version we're migrating from
-        to_version = store.persistent._jn_version
+        #Set from_version to the version we're migrating from
+        from_version = store.persistent._jn_version
 
-        while compareVersions(to_version, renpy.config.version) < 0:
+        #If the current version (config.version) is greater than the version we've got stored (or migrating from)
+        #We should loop until we've caught up
+        while compareVersions(from_version, renpy.config.version) < 0:
             #First, check if there's a late migration we need to run
             if MigrationRuntimes.RUNTIME in UPDATE_FUNCS[store.persistent._jn_version]:
                 LATE_UPDATES.append(UPDATE_FUNCS[store.persistent._jn_version][MigrationRuntimes.RUNTIME])
 
             #We're below the latest version, so we need to migrate to the next one in the chain
-            _callable, to_version = UPDATE_FUNCS[to_version][MigrationRuntimes.RUNTIME]
+            _callable, from_version = UPDATE_FUNCS[from_version][MigrationRuntimes.RUNTIME]
 
             #Migrate
             _callable()
@@ -138,7 +140,11 @@ python early in jn_data_migrations:
 init 10 python:
     jn_data_migrations.runInitMigrations()
 
+
+#All migration scripts go here
 init python in jn_data_migrations:
-    @migration(["0.0.0"], "0.0.1")
-    def v0_0_0_to_0_0_1():
+    #This runs a migration from version 0.0.0 to 0.0.1
+    #This script serves an example and hence, does nothing. All arguments are present however "runtime" is not necessary
+    @migration(["0.0.0"], "0.0.1", runtime=MigrationRuntimes.INIT)
+    def to_0_0_1():
         pass

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -1,0 +1,141 @@
+python early in jn_data_migrations:
+    from enum import Enum
+    import re
+    from renpy.store import persistent
+
+    # dict mapping a from_version -> to_version, including the function used to migrate between those versions
+    # form:
+    # "x.y.z": {
+    #    MigrationRuntimes.INIT: (callable, "x.y.z"),
+    #    MigrationRuntimes.RUNTIME: (callable, "x.y.z")
+    #},
+    UPDATE_FUNCS = dict()
+
+    # list containing the late (during runtime) migrations we need to run. These will simply be run in order.
+    LATE_UPDATES = []
+
+    #Parses x.x.x.x (suffix) to a regex match with two groups:
+    # ver and suffix
+    VER_STR_PARSER = re.compile(r"^(?P<ver>\d+\.\d+\.\d+)(?P<suffix>.*)$")
+
+    class MigrationRuntimes(Enum):
+        """
+        Enum for the times to run migration scripts.
+        """
+        INIT = 1
+        RUNTIME = 2
+
+    def migration(from_versions, to_version, runtime=MigrationRuntimes.INIT):
+        """
+        Decorator function to register a data migration function
+
+        IN:
+            from_versions: list of versions to migrate from
+            to_version: version to migrate to
+            during_runtime: whether the migration is run during runtime. If False, it is run during init 10
+                (Default: MigrationRuntimes.INIT)
+
+        OUT:
+            the wrapper function
+        """
+        def wrap(_function):
+            registerUpdateFunction(
+                _function,
+                from_versions,
+                to_version,
+                during_runtime
+            )
+            return _function
+        return wrap
+
+    def registerUpdateFunction(_callable, from_versions, to_version, runtime=MigrationRuntimes.INIT):
+        """
+        Register a function to be called when the program is updated.
+
+        IN:
+            _callable: the function to run (Must take no arguments)
+            from_versions: list of versions to migrate from
+            to_version: version to migrate to
+            during_runtime: whether the migration is run during runtime. If False, it is run during init 10
+                (Default: MigrationRuntimes.INIT)
+        """
+        for from_version in from_versions:
+            if from_version not in UPDATE_FUNCS:
+                UPDATE_FUNCS[from_version] = dict()
+
+            UPDATE_FUNCS[from_version][runtime] = (_callable, to_version)
+
+    def ver_string_to_ver_list(ver_str):
+        """
+        Converts a version string to a list of integers representing the version.
+        """
+        match = VER_STR_PARSER.match(ver_str)
+        if not match:
+            raise ValueError("Invalid version string.")
+
+        ver_list = match.group("ver").split(".")
+        return [int(x) for x in ver_list]
+
+    def compare_versions(ver_str1, ver_str2):
+        """
+        Compares two version strings.
+        """
+        match1 = VER_STR_PARSER.match(ver_str1)
+        match2 = VER_STR_PARSER.match(ver_str2)
+
+        if not match1 or not match2:
+            raise ValueError("Invalid version string.")
+
+        ver1 = ver_string_to_ver_list(match1.group("ver"))
+        ver2 = ver_string_to_ver_list(match2.group("ver"))
+
+        #Check the lengths of the versions, we'll pad the shorter one with zeros
+        if len(ver1) > len(ver2):
+            ver2 += [0] * (len(ver1) - len(ver2))
+        elif len(ver1) < len(ver2):
+            ver1 += [0] * (len(ver2) - len(ver1))
+
+        #Now directly compare from left to right
+        for i in range(len(ver1)):
+            if ver1[i] > ver2[i]:
+                return 1
+            elif ver1[i] < ver2[i]:
+                return -1
+
+        #If we got here, the versions are equal
+        return 0
+
+    def runInitMigrations():
+        """
+        Runs init time migration functions. Must be run after init 0
+        """
+        #We do nothing here if the version isn't in the dict
+        if persistent._jn_version not in UPDATE_FUNCS:
+            return
+
+        #Set to_version to the version we're migrating from
+        to_version = persistent._jn_version
+
+        while compare_versions(to_version, renpy.config.version) < 0:
+            #First, check if there's a late migration we need to run
+            if MigrationRuntimes.RUNTIME in UPDATE_FUNCS[persistent._jn_version]:
+                LATE_UPDATES.append(UPDATE_FUNCS[persistent._jn_version][MigrationRuntimes.RUNTIME])
+
+            #We're below the latest version, so we need to migrate to the next one in the chain
+            _callable, to_version = UPDATE_FUNCS[to_version][MigrationRuntimes.RUNTIME]
+
+            #Migrate
+            _callable()
+
+    def runRuntimeMigrations():
+        """
+        Runs the runtime migration functions.
+        """
+        for _callable in LATE_UPDATES:
+            _callable()
+
+#Init time migrations are run at init 10
+init 10 python:
+    jn_data_migrations.runInitMigrations()
+
+init python in jn_data_migrations:


### PR DESCRIPTION
Adds a system to perform data migrations across versions
This allows us to run updates to migrate vars/persistent info as necessary to acommodate API changes and the like to ensure the same persistent can be used going forward in JN development. This also allows us to start formally versioning, and building/distributing releases once merged.

# Key Additions:
- The `jn_data_migrations` store
- The `migration` decorator

# How to use:
Creating updates are a simple process, the key thing to keep in mind is that there are only **2** levels at which we run updates:
1. `init 10`
2. in `ch30_init`

This is due to potential race conditions and conflicts in old/new updates.

To create an update, simply define a function at the bottom of `zz_data-migrations.rpy`, and add the `@migration` decorator.
- The first argument can accept multiple versions that consolidate to a single version to migrate to, allowing reduction of duplicated code which would be identical of two version moving to the same single version.
- The second argument is the version being migrated to.
- The final argument is optional, this indicates when this function is being run. Either at init 10 or actual runtime. This is marked by the enum `MigrationRuntimes` which has `INIT` and `RUNTIME` as values.

As an additional, it is theoretically possible for an update script to be run more than once, provided the stored old version does not change and/or the user has reverted to an old build, then back up to a new build.
That said, updates past the current version of the game (defined by `config.version`) will not be run.

# Testing:
- Create your own updates and validate they're run when appropriate, as well validate the different runtime levels work appropriately too.
- Verify no crashes