### PR TITLE
Player name changes

### DIFF
--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1693,20 +1693,9 @@ init python:
     s_name = "Sayori"
     m_name = "Monika"
     y_name = "Yuri"
+    n_name = "Natsuki"
 
-    # Assign Natsuki the chosen nickname (defaulted to Natsuki)
-    if persistent._jn_nicknames_natsuki_current_nickname:
-        n_name = persistent._jn_nicknames_natsuki_current_nickname
-
-    else:
-        n_name = "Natsuki"
-
-    # Assign the player their chosen nickname (defaulted to the name they gave in the intro)
-    if persistent._jn_nicknames_player_current_nickname:
-        player = persistent._jn_nicknames_player_current_nickname
-
-    else:
-        player = persistent.playername
+    player = persistent.playername
 
 init -999 python:
     def label_callback(name, abnormal):

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1693,8 +1693,8 @@ init python:
     s_name = "Sayori"
     m_name = "Monika"
     y_name = "Yuri"
+    
     n_name = "Natsuki"
-
     player = persistent.playername
 
 init -999 python:

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1695,11 +1695,18 @@ init python:
     y_name = "Yuri"
 
     # Assign Natsuki the chosen nickname (defaulted to Natsuki)
-    if persistent.jn_player_nicknames_current_nickname:
-        n_name = persistent.jn_player_nicknames_current_nickname
+    if persistent._jn_nicknames_natsuki_current_nickname:
+        n_name = persistent._jn_nicknames_natsuki_current_nickname
 
     else:
         n_name = "Natsuki"
+
+    # Assign the player their chosen nickname (defaulted to the name they gave in the intro)
+    if persistent._jn_nicknames_player_current_nickname:
+        player = persistent._jn_nicknames_player_current_nickname
+
+    else:
+        player = persistent.playername
 
 init -999 python:
     def label_callback(name, abnormal):

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1151,7 +1151,7 @@ init -990 python in jn_globals:
         "pigfucker",
         "pimpis",
         "piss",
-        "poop",
+        "poo|poop",
         "prick",
         "pube",
         "rectum",
@@ -1169,7 +1169,7 @@ init -990 python in jn_globals:
         "smegma",
         "smut",
         "snatch",
-        "son-of-a-bitch",
+        "son-of-a-bitch|sonofabitch",
         "spac",
         "spunk",
         "tosser",
@@ -1185,6 +1185,93 @@ init -990 python in jn_globals:
         "whore",
         "xrated",
         "xxx"
+    }
+
+    _INSULT_LIST = {
+        "arrogant",
+        "beast",
+        "bonebag",
+        "bonehead",
+        "brat|bratty",
+        "breadboard",
+        "bully",
+        "cheater",
+        "child",
+        "clown",
+        "cuttingboard",
+        "demon",
+        "dimwit",
+        "dirt",
+        "disgusting",
+        "^dog$",
+        "dumb|dumbo",
+        "dunce",
+        "dwarf",
+        "dweeb",
+        "egoist|egotistical",
+        "evil",
+        "failure",
+        "fake",
+        "(^fat$|fatso|fatty)",
+        "(flat|flatso|flatty)",
+        "gilf",
+        "gremlin",
+        "gross",
+        "halfling|halfpint|half-pint",
+        "halfwit",
+        "heartless",
+        "hellspawn",
+        "hideous",
+        "horrid|horrible",
+        "hungry",
+        "idiot",
+        "ignoramus",
+        "ignorant",
+        "imbecile",
+        "^imp$",
+        "ironingboard",
+        "(^kid$|kiddo|kiddy|kiddie)",
+        "l[e3]sbian",
+        "l[e3]sb[o0]",
+        "midget",
+        "moron",
+        "narcissist",
+        "nasty",
+        "neckcrack|neck-crack",
+        "necksnap|neck-snap",
+        "nimrod",
+        "nuisance",
+        "^pest$",
+        "pathetic",
+        "plaything",
+        "punchbag|punch-bag|punchingbag|punching-bag",
+        "puppet",
+        "putrid",
+        "^short$|shortstuff|shorty",
+        "^sick$",
+        "^simp$",
+        "simpleton",
+        "skinny",
+        "slave",
+        "smelly",
+        "^soil$",
+        "starved|starving",
+        "stinky",
+        "^(stuckup|stuck-up)$"
+        "stupid",
+        "^teabag$",
+        "^th[o0]t$",
+        "^tiny$",
+        "^toy$",
+        "^twerp$",
+        "^twit$",
+        "^useless$",
+        "^vendingmachine$",
+        "vomit",
+        "^washboard$",
+        "^witch$",
+        "^wretch$",
+        "^zombie$",
     }
 
     # Alphabetical (excluding numbers) values allowed for text input
@@ -1365,7 +1452,8 @@ init python in jn_utils:
     import store
     import store.jn_globals as jn_globals
 
-    __PROFANITY_REGEX = re.compile('|'.join(jn_globals._PROFANITY_LIST), re.IGNORECASE)
+    PROFANITY_REGEX = re.compile('|'.join(jn_globals._PROFANITY_LIST), re.IGNORECASE)
+    INSULT_REGEX = re.compile('|'.join(jn_globals._INSULT_LIST), re.IGNORECASE)
 
     def get_current_session_length():
         """
@@ -1486,7 +1574,19 @@ init python in jn_utils:
         OUT:
             - True if string contains profanity; otherwise False
         """
-        return re.search(__PROFANITY_REGEX, string.lower())
+        return re.search(PROFANITY_REGEX, string.lower())
+
+    def get_string_contains_insult(string):
+        """
+        Returns True if the given string contains an insult, based on regex.
+
+        IN:
+            - string - The string to test
+
+        OUT:
+            - True if string contains an insult; otherwise False
+        """
+        return re.search(INSULT_REGEX, string.lower())
 
     # Key setup
     key_path = os.path.join(renpy.config.basedir, "game/dev/key.txt").replace("\\", "/")

--- a/game/script-apologies.rpy
+++ b/game/script-apologies.rpy
@@ -21,6 +21,7 @@ init 0 python in jn_apologies:
     TYPE_SUDDEN_LEAVE = 6
     TYPE_UNHEALTHY = 7
     TYPE_SCARE = 8
+    TYPE_BAD_PLAYER_NAME = 9
 
     def get_all_apologies():
         """

--- a/game/script-apologies.rpy
+++ b/game/script-apologies.rpy
@@ -90,7 +90,7 @@ init 5 python:
     )
 
 label apology_bad_nickname:
-    if persistent.jn_player_nicknames_allowed:
+    if persistent._jn_nicknames_natsuki_allowed:
         # The player is still capable of nicknaming Natsuki
         if Natsuki.isEnamored(higher=True):
             n 1kcssf "..."
@@ -611,4 +611,133 @@ label apology_scare:
         n 1fcsantsa "We both know you don't mean that."
 
     $ persistent.jn_player_pending_apologies.remove(jn_apologies.TYPE_SCARE)
+    return
+
+# Apology for giving Natsuki a bad nickname
+init 5 python:
+    registerTopic(
+        Topic(
+            persistent._apology_database,
+            prompt="For asking you to call me a bad name.",
+            label="apology_bad_player_name",
+            unlocked=True,
+            conditional="jn_apologies.get_apology_type_pending(jn_apologies.TYPE_BAD_PLAYER_NAME)"
+        ),
+        topic_group=TOPIC_TYPE_APOLOGY
+    )
+
+label apology_bad_player_name:
+    if persistent._jn_nicknames_player_allowed:
+        # The player is still capable of nicknaming Natsuki
+        if Natsuki.isEnamored(higher=True):
+            n 1ncspuesi "..."
+            n 1nllsl "...It's fine,{w=0.1} [player]."
+            n 1ncsaj "Just..."
+            n 1ksrsl "..."
+            n 1kcstr "I really hate when I try to do something nice...{w=1}{nw}"
+            extend 1ksqsr " and it just gets thrown back in my face,{w=0.1} you know?"
+            n 1fcstr "I didn't {i}have{/i} to listen to what you wanted."
+            n 1knmsrl "...So do you seriously think saying stuff like that {i}makes{/i} me want to do that again in the future?"
+            n 1fllsrl "Because it {i}doesn't{/i},{w=0.1} [player]."
+            n 1fcssrl "..."
+            n 1kcsajsbl "...Look.{w=1}{nw}"
+            extend 1nllpul " It's all water under the bridge,{w=0.1} okay?{w=0.75}{nw}"
+            extend 1fllpol " I accept your apology."
+            n 1fnmpol "Just use your noggin next time.{w=0.75}{nw}"
+            extend 1fcspol " I {i}know{/i} there's one on your shoulders somewhere."
+            n 1fsrunl "...Just don't start trying to prove me wrong on that.{w=0.75}{nw}"
+            extend 1ksqpol " Please?"
+            $ Natsuki.calculatedAffinityGain()
+
+        elif Natsuki.isNormal(higher=True):
+            n 1tnmpueqm "...Huh?{w=1}{nw}"
+            extend 1nnmsl " Oh,{w=0.3} right.{w=0.75}{nw}"
+            extend 1fslbol " The whole name thing."
+            n 1ncspuesi "..."
+            n 1fsqca "...That was still a jerkish thing to do,{w=0.5}{nw}"
+            extend 1fslca " you know."
+            n 1fcsemlsbl "You're just lucky I don't keep pointless grudges forever." 
+            extend 1fcsca " I'm a bigger person than that."
+            n 1nllaj "So...{w=1}{nw}"
+            extend 1nnmsl " you're forgiven.{w=0.75}{nw}"
+            extend 1nsrbo " I guess."
+            n 1fnmcal "Just think about what you come out with.{w=0.5}{nw}"
+            extend 1ksrcalsbr " It really isn't hard,{w=0.1} is it?"
+            $ Natsuki.calculatedAffinityGain()
+
+        elif Natsuki.isDistressed(higher=True):
+            n 1fcsan "...You are just unbelievable,{w=0.1} [player]."
+            n 1fsqfu "Did it {i}seriously{/i} take you this long to admit you were wrong to say that?"
+            n 1flrem "Like,{w=0.5}{nw}"
+            extend 1fnmsc " are you {i}trying{/i} to be funny?"
+            n 1fsqup "...Or are you really just {b}that{/b} arrogant?"
+            n 1fcsan "..."
+            n 1fsqanean "...You know what?{w=0.5}{nw}"
+            extend 1fcsfuean " Fine.{w=1}{nw}"
+            extend 1fllwr " Who cares?{w=0.75}{nw}"
+            extend 1fsqfultsb " You clearly don't."
+            n 1fcsfrtsa "I'll accept your half-baked {i}attempt{/i} at an apology."
+            n 1fsqfutsb "But only because it's less effort than getting angry about it."
+
+        else:
+            n 1fsquntdr "Heh.{w=0.75}{nw}"
+            extend 1fsqantsb " {i}Now{/i} you apologize,{w=0.1} huh?"
+            n 1fnmanltsfean "After all this time?"
+            n 1fcsanltsd "..."
+            n 1fcsfultsa "You know what?{w=1}{nw}"
+            extend 1fsqfultsb " Maybe I {i}should{/i} just call you that name."
+            n 1fskscftdc "Why not?!{w=1}{nw}"
+            extend 1fskfuftdc " Not like you {i}aren't{/i} acting like it."
+            extend 1fcsanltsd " Jerk."
+
+    else:
+        # The player has been barred from nicknaming Natsuki,{w=0.1} and even an apology won't change that
+        if Natsuki.isEnamored(higher=True):
+            n 1nllsl "..."
+            n 1knmsl "[player]."
+            n 1knmaj "...Exactly how many times did I warn you?"
+            n 1fnmem "How many times did I {i}forgive{/i} you?{w=1}{nw}"
+            extend 1fcsemean " Because I honestly lost count."
+            n 1kcsfresi "..."
+            n 1nsqsr "Sorry,{w=0.1} [player].{w=0.5}{nw}"
+            extend 1flltr " Every joke runs its course."
+            n 1fsqunl "And I am {i}not{/i} going to be the butt of this one again."
+            n 1fcsajl "So."
+            n 1fllcal "Fine.{w=0.5} I'll accept your apology..."
+            n 1fsqcalesi "...And you're going to accept the consequences."
+            n 1fcstrl "Sorry,{w=0.3} [player]."
+            extend 1fsqbol " But we're done with names here."
+            $ Natsuki.calculatedAffinityGain()
+
+        elif Natsuki.isNormal(higher=True):
+            n 1fcsemesi "...You've got to be kidding me,{w=0.5} right?"
+            n 1fllaj "You were a jerk so many times to me about that..."
+            n 1fsqan "...And you leave it this long to even {i}apologize{/i}?"
+            n 1fcsemesi "..."
+            n 1fsqtr "You're just lucky I'm not one for holding dumb grudges."
+            n 1fcsaj "So,{w=0.3} [player]."
+            n 1fslpo "I guess I'll accept the apology."
+            n 1fnmfr "...But you can {i}forget{/i} about me accepting any more of your nicknames."
+            n 1fsqtr "I'm done being messed around."
+            $ Natsuki.calculatedAffinityGain()
+
+        elif Natsuki.isDistressed(higher=True):
+            n 1fcsan "{i}Wow{/i}.{w=1}{nw}"
+            extend 1fcsfu " I would say I'm speechless,{w=0.3} if it were literally {i}anyone{/i} else."
+            n 1fsqfuean "But {i}you{/i}?"
+            n 1fcsem "I've about come to {i}expect{/i} this sort of crap from you."
+            n 1fsqwrean "So you know what?{w=0.75}{nw}"
+            extend 1fcssclean " Screw this,{w=0.75}{nw}"
+            extend 1fskscltsc " and screw your apology!"
+            n 1fcsscltsa "If {i}you{/i} aren't gonna listen,{w=0.5}{nw}"
+            extend 1fllscltsc " then you can tell me why I {b}should{/b}!"
+
+        else:
+            n 1fcsfultdrean "Oh,{w=1}{nw}"
+            extend 1fcsscltsaean " take a hike,{w=0.5}{nw}"
+            extend 1fsqscltsbean " [player]!"
+            n 1fcswrltsd "You {i}need{/i} a walk if you {i}seriously{/i} think after all of your crap,{w=0.75}{nw}"
+            extend 1fskwrftdcean " I'm gonna be the one listening to {b}you{/b}!"
+
+    $ persistent.jn_player_pending_apologies.remove(jn_apologies.TYPE_BAD_PLAYER_NAME)
     return

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -46,6 +46,14 @@ label ch30_init:
         #Now adjust the stored version number
         persistent._jn_version = config.version
 
+        # Assign Natsuki her nickname, if permitted and defined
+        if persistent._jn_nicknames_natsuki_allowed and persistent._jn_nicknames_natsuki_current_nickname:
+            n_name = persistent._jn_nicknames_natsuki_current_nickname
+
+        # Assign the player their chosen nickname, if permitted and defined
+        if persistent._jn_nicknames_player_allowed and persistent._jn_nicknames_player_current_nickname:
+            player = persistent._jn_nicknames_player_current_nickname
+
         # Check the daily affinity cap and reset if need be
         Natsuki.checkResetDailyAffinityGain()
 

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -47,12 +47,9 @@ label ch30_init:
         persistent._jn_version = config.version
 
         # TODO: weird visual bug, like Nat's sprite sometimes doesn't load for the first line, but fine after?
-
-        # Assign Natsuki her nickname, if permitted and defined
         if persistent._jn_nicknames_natsuki_allowed and persistent._jn_nicknames_natsuki_current_nickname:
             n_name = persistent._jn_nicknames_natsuki_current_nickname
 
-        # Assign the player their chosen nickname, if permitted and defined
         if persistent._jn_nicknames_player_allowed and persistent._jn_nicknames_player_current_nickname:
             player = persistent._jn_nicknames_player_current_nickname
 

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -46,6 +46,8 @@ label ch30_init:
         #Now adjust the stored version number
         persistent._jn_version = config.version
 
+        # TODO: weird visual bug, like Nat's sprite sometimes doesn't load for the first line, but fine after?
+
         # Assign Natsuki her nickname, if permitted and defined
         if persistent._jn_nicknames_natsuki_allowed and persistent._jn_nicknames_natsuki_current_nickname:
             n_name = persistent._jn_nicknames_natsuki_current_nickname

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -46,7 +46,7 @@ label ch30_init:
         #Now adjust the stored version number
         persistent._jn_version = config.version
 
-        # TODO: weird visual bug, like Nat's sprite sometimes doesn't load for the first line, but fine after?
+        # Assign Natsuki and player nicknames
         if persistent._jn_nicknames_natsuki_allowed and persistent._jn_nicknames_natsuki_current_nickname:
             n_name = persistent._jn_nicknames_natsuki_current_nickname
 

--- a/game/script-introduction.rpy
+++ b/game/script-introduction.rpy
@@ -211,7 +211,7 @@ label introduction_first_meeting:
         if len(player_name) == 0:
             n 1kskem "P-{w=0.3}please!{w=1} Who are you?!"
 
-        elif jn_utils.get_string_contains_profanity(player_name):
+        elif jn_utils.get_string_contains_profanity(player_name) or jn_utils.get_string_contains_insult(player_name):
             # We only apply penalty once here so we don't have to rewrite the whole sequence for diff aff/trust levels
             if persistent._jn_player_profanity_during_introduction:
                 play audio static

--- a/game/script-nicknames.rpy
+++ b/game/script-nicknames.rpy
@@ -5,7 +5,7 @@ default persistent._jn_nicknames_natsuki_bad_given_total = 0
 
 # Player nickname data
 default persistent._jn_nicknames_player_allowed = True
-default persistent._jn_nicknames_player_current_nickname = None
+default persistent._jn_nicknames_player_current_nickname = persistent.playername
 default persistent._jn_nicknames_player_bad_given_total = 0
 
 init 0 python in jn_nicknames:
@@ -149,6 +149,7 @@ init 0 python in jn_nicknames:
         "^geek$",
         "^girl$",
         "^boy$",
+        "thiccsuki"
     }
 
     NATSUKI_LOVED_NICKNAME_REGEX = re.compile('|'.join(__NATSUKI_NICKNAME_LOVED_LIST), re.IGNORECASE)
@@ -175,8 +176,11 @@ init 0 python in jn_nicknames:
         
         else:
             nickname = nickname.lower().replace(" ", "")
+
+            if nickname == "":
+                return NicknameTypes.invalid
             
-            if re.search(NATSUKI_LOVED_NICKNAME_REGEX, nickname):
+            elif re.search(NATSUKI_LOVED_NICKNAME_REGEX, nickname):
                 return NicknameTypes.loved
 
             elif re.search(NATSUKI_FUNNY_NICKNAME_REGEX, nickname):
@@ -213,6 +217,9 @@ init 0 python in jn_nicknames:
         
         else:
             nickname = nickname.lower().replace(" ", "")
+
+            if nickname == "":
+                return NicknameTypes.invalid
 
             if re.search(PLAYER_FUNNY_NICKNAME_REGEX, nickname):
                 return NicknameTypes.funny

--- a/game/script-nicknames.rpy
+++ b/game/script-nicknames.rpy
@@ -1,313 +1,230 @@
-# Nickname data
-default persistent.jn_player_nicknames_allowed = True
-default persistent.jn_player_nicknames_current_nickname = "Natsuki"
-default persistent.jn_player_nicknames_bad_given_total = 0
+# Natsuki nickname data
+default persistent._jn_nicknames_natsuki_allowed = True
+default persistent._jn_nicknames_natsuki_current_nickname = "Natsuki"
+default persistent._jn_nicknames_natsuki_bad_given_total = 0
+
+# Player nickname data
+default persistent._jn_nicknames_player_allowed = True
+default persistent._jn_nicknames_player_current_nickname = None
+default persistent._jn_nicknames_player_bad_given_total = 0
 
 init 0 python in jn_nicknames:
+    from Enum import Enum
+    import re
+    import store
     import store.jn_globals as jn_globals
     import store.jn_utils as jn_utils
     
-    # Nickname types
-    TYPE_INVALID = 0
-    TYPE_LOVED = 1
-    TYPE_NEUTRAL = 2
-    TYPE_DISLIKED = 3
-    TYPE_HATED = 4
-    TYPE_PROFANITY = 5
-    TYPE_FUNNY = 6
-    TYPE_NOU = 7
-    
+    class NicknameTypes(Enum):
+        """
+        Identifiers for different nickname types.
+        """
+        invalid = 1
+        loved = 2
+        neutral = 3
+        disliked = 4
+        hated = 5
+        profanity = 6
+        funny = 7
+        nou = 8
+
     # Natsuki loves these nicknames; awarding them awards affinity/trust
-    NICKNAME_LOVED_LIST = {
-        "babe",
-        "amazing",
-        "angel",
-        "babygirl",
-        "baby",
-        "babycakes",
-        "beautiful",
-        "bestgirl",
-        "betterhalf",
-        "boo",
-        "bunbun",
-        "bun-bun",
-        "bunny",
-        "buttercup",
-        "butterscotch",
-        "candy",
-        "cookie",
-        "cupcake",
-        "cuteypie",
-        "cutey",
-        "cutiepie",
-        "cutie",
-        "darlin",
-        "darling",
-        "doll",
-        "dollface",
-        "dove",
-        "gem",
-        "gorgeous",
-        "heartstring",
-        "heart-string",
-        "heartthrob",
-        "heart-throb",
-        "heaven",
-        "honey",
-        "honeybun",
-        "hun",
-        "ki",
-        "kitten",
-        "kitty",
-        "love",
-        "mine",
-        "myflower",
-        "mylove",
-        "mylovely",
-        "myprincess",
-        "myqueen",
-        "myrose",
-        "natnat",
-        "nat",
-        "nat-nat",
-        "natsu",
-        "natsukitten",
-        "natsukitty",
-        "natty",
-        "nattykins",
-        "numberone",
-        "precious",
-        "princess",
-        "qtpie",
-        "qt",
-        "queen",
-        "snooki",
-        "snookums",
-        "special",
-        "squeeze",
-        "starlight",
-        "starshine",
-        "su",
-        "sugar",
-        "sugarlump",
-        "sugarplum",
-        "'suki",
-        "suki",
-        "summer",
-        "sunny",
-        "sunshine",
-        "sweetcakes",
-        "sweetpea",
-        "sweetheart",
-        "sweetie",
-        "sweetness",
-        "sweety"
-        "thebest"
+    __NATSUKI_NICKNAME_LOVED_LIST = {
+        "^amazing$",
+        "^angel$",
+        "^(babe|baby|babygirl)$",
+        "^babycakes$",
+        "^beautiful$",
+        "^bestgirl$",
+        "^betterhalf$",
+        "^boo$",
+        "^(bunbun|bun-bun|bunny)$",
+        "^(butter(cup|scotch))$",
+        "^candy$",
+        "^cookie$",
+        "^cupcake$",
+        "^(cutey|cutie|cuteypie|cutiepie)$",
+        "^(darlin|darling)$",
+        "^(doll|dollface)$",
+        "^dove$",
+        "^gem$",
+        "^gorgeous$",
+        "^(heartstring|heart-string|heartthrob|heart-throb)$",
+        "^heaven$",
+        "^(honey|honeybun)$",
+        "^hun$",
+        "^ki$",
+        "^(kitty|kitten)$",
+        "^love$",
+        "^mine$",
+        "^myflower$",
+        "^(mylove|mylovely)$",
+        "^myprincess$",
+        "^myqueen$",
+        "^myrose$",
+        "^(nat|natnat|nat-nat)$",
+        "^(natsu|natsukitten|natsukitty)$",
+        "^(natty|nattykins)$",
+        "^number(one|1)$",
+        "^precious$",
+        "^princess$",
+        "^(qt|qtpie)$",
+        "^(queen|myqueen)$",
+        "^(snooki|snookums)$",
+        "^special$",
+        "^squeeze$",
+        "^(starlight|starshine)$",
+        "^su$",
+        "^(sugar|sugarlump|sugarplum)$",
+        "^'suki$",
+        "^suki$",
+        "^summer$",
+        "^(sunny|sunshine)$",
+        "^(sweetcakes|sweetpea|sweetheart|sweetness|sweety)$",
+        "^thebest$",
     }
 
     # Natsuki dislikes these nicknames; no penalty given but name will not be permitted
-    NICKNAME_DISLIKED_LIST = {
-        "dad",
-        "daddy",
-        "father",
-        "lily",
-        "moni",
-        "monika",
-        "monikins",
-        "monmon",
-        "mon-mon",
-        "papa",
-        "sayo",
-        "sayori",
-        "yori",
-        "yuri",
-        "weeb"
-    }
-
-    # Natsuki hates these (non-profanity) nicknames; awarding them detracts affinity/trust
-    NICKNAME_HATED_LIST={
-        "arrogant",
-        "beast",
-        "bonebag",
-        "bonehead",
-        "brat",
-        "bratty",
-        "breadboard",
-        "bully",
-        "cheater",
-        "child",
-        "clown",
-        "cuttingboard",
-        "demon",
-        "dimwit",
-        "dirt",
-        "disgusting",
-        "dog",
-        "dumb",
-        "dumbo",
-        "dumbo",
-        "dunce",
-        "dwarf",
-        "dweeb",
-        "egoist",
-        "egotistical",
-        "evil",
-        "failure",
-        "fake",
-        "fat",
-        "fatso",
-        "fatty",
-        "flat",
-        "flatso",
-        "flatty",
-        "gilf",
-        "gremlin",
-        "gross",
-        "halfling",
-        "halfpint",
-        "half-pint",
-        "halfwit",
-        "heartless",
-        "hellspawn",
-        "hideous",
-        "horrible",
-        "horrid",
-        "hungry",
-        "idiot",
-        "ignoramus",
-        "ignorant",
-        "imbecile",
-        "imp",
-        "ironingboard",
-        "kid",
-        "lesbian",
-        "lesbo",
-        "midget",
-        "moron",
-        "narcissist",
-        "nasty",
-        "neckcrack",
-        "neck-crack",
-        "necksnap",
-        "neck-snap",
-        "nerd",
-        "nimrod",
-        "nuisance",
-        "pest",
-        "plaything"
-        "punchbag",
-        "punch-bag",
-        "punchingbag",
-        "punching-bag",
-        "puppet",
-        "putrid",
-        "short",
-        "shortstuff",
-        "shorty",
-        "sick",
-        "simp",
-        "simpleton",
-        "skinny",
-        "slave",
-        "smelly",
-        "soil",
-        "starved",
-        "starving",
-        "stinky",
-        "stuckup"
-        "stuck-up",
-        "stupid",
-        "teabag",
-        "thot",
-        "tiny",
-        "toy",
-        "twerp",
-        "twit",
-        "useless",
-        "vendingmachine",
-        "vomit",
-        "washboard",
-        "witch",
-        "wretch",
-        "zombie"
+    __NATSUKI_NICKNAME_DISLIKED_LIST = {
+        "^(dad|daddy)$",
+        "^father$",
+        "^lily$",
+        "^(moni$|moni([ck])a|monikins|monmon|mon-mon)$",
+        "^papa$",
+        "^(sayo|sayori)$",
+        "^(salvato|dansalvato)$",
+        "^metaverse$",
+        "^yori$",
+        "^yuri$",
+        "^weeb$",
+        "(playboy|playgirl)",
     }
 
     # Natsuki finds these nicknames funny
-    NICKNAME_FUNNY_LIST = {
-        "catsuki",
-        "gorgeous",
-        "hot",
-        "hotstuff",
-        "hottie",
-        "nyatsuki",
-        "mama",
-        "mom",
-        "mommy",
-        "mother",
-        "mum",
-        "mummy",
-        "sexy",
-        "smol",
-        "snack"
+    __NATSUKI_NICKNAME_FUNNY_LIST = {
+        "^catsuki$",
+        "^gorgeous$",
+        "^(hot|hotstuff|hottie)$",
+        "^nyatsuki$",
+        "^mama$",
+        "^(mom|mommy|mother)$",
+        "^(mum|mummy|maam|ma'am)$",
+        "^sexy$",
+        "^smol$",
+        "^snack$",
     }
 
-    NICKNAME_NOU_LIST = {
-        "adorkable",
-        "baka",
-        "booplicate",
-        "booplic8",
-        "booplik8",
-        "boopliqeeb",
-        "boopliqeb",
-        "dummy",
-        "qab",
-        "qeb",
-        "qeeb",
-        "qebqeb",
-        "qebweb",
-        "qib",
-        "qob",
-        "qoob",
-        "qub",
-        "web",
-        "webqeb",
-        "woob",
-        "wob"
+    # Nou
+    __NATSUKI_NICKNAME_NOU_LIST = {
+        "^adorkable$",
+        "^baka$",
+        "^(booplicate|boopli[ck]8|boopliq(ee|e|3|33)b)$",
+        "^dummy$",
+        "^(q[eaoui]b|q[eaoui][eaoui]b|q[eaoui]b[wq][eaoui]b)$",
+        "^(w[eaoui]b|w[eaoui][eaoui]b|w[eaoui]b[wq][eaoui]b)$",
     }
 
-    def get_nickname_type(nickname):
+    # Natsuki dislikes these nicknames; no penalty given but name will not be permitted
+    __PLAYER_NICKNAME_DISLIKED_LIST = {
+        "^(dad|daddy)$",
+        "^father$",
+        "^papa$",
+        "^(salvato|dansalvato)$",
+        "^metaverse$",
+        "(playboy|playgirl)",
+        "nerd"
+    }
+
+    # Natsuki finds these nicknames funny
+    __PLAYER_NICKNAME_FUNNY_LIST = {
+        "^gorgeous$",
+        "^(hot|hotstuff|hottie)$",
+        "^(mom|mommy|mother)$",
+        "^(mum|mummy|maam|ma'am)$",
+        "^mama$",
+        "^sexy$",
+        "^weeb$",
+        "^dork$",
+        "^nerd$",
+        "^geek$",
+        "^girl$",
+        "^boy$",
+    }
+
+    NATSUKI_LOVED_NICKNAME_REGEX = re.compile('|'.join(__NATSUKI_NICKNAME_LOVED_LIST), re.IGNORECASE)
+    NATSUKI_DISLIKED_NICKNAME_REGEX = re.compile('|'.join(__NATSUKI_NICKNAME_DISLIKED_LIST), re.IGNORECASE)
+    NATSUKI_FUNNY_NICKNAME_REGEX = re.compile('|'.join(__NATSUKI_NICKNAME_FUNNY_LIST), re.IGNORECASE)
+    NATSUKI_NOU_NICKNAME_REGEX = re.compile('|'.join(__NATSUKI_NICKNAME_NOU_LIST), re.IGNORECASE)
+
+    PLAYER_DISLIKED_NICKNAME_REGEX = re.compile('|'.join(__PLAYER_NICKNAME_DISLIKED_LIST), re.IGNORECASE)
+    PLAYER_FUNNY_NICKNAME_REGEX = re.compile('|'.join(__PLAYER_NICKNAME_FUNNY_LIST), re.IGNORECASE)
+
+    def get_natsuki_nickname_type(nickname):
         """
-        Returns the nickname type for a given string nickname, defaulting to TYPE_NEUTRAL
+        Returns the NicknameTypes type for a given string nickname for Natsuki, defaulting to NatsukiNicknameTypes.neutral
 
         IN:
             nickname - The nickname to test
+
         OUT:
-            Nickname type, integer as defined in constant list
+            NicknameTypes type of the given nickname
         """
 
         if not isinstance(nickname, basestring):
-            return TYPE_INVALID
+            return NicknameTypes.invalid
+        
+        else:
+            nickname = nickname.lower().replace(" ", "")
+            
+            if re.search(NATSUKI_LOVED_NICKNAME_REGEX, nickname):
+                return NicknameTypes.loved
+
+            elif re.search(NATSUKI_FUNNY_NICKNAME_REGEX, nickname):
+                return NicknameTypes.funny
+
+            elif re.search(NATSUKI_DISLIKED_NICKNAME_REGEX, nickname):
+                return NicknameTypes.disliked
+
+            elif jn_utils.get_string_contains_insult(nickname):
+                return NicknameTypes.hated
+
+            elif jn_utils.get_string_contains_profanity(nickname):
+                return NicknameTypes.profanity
+
+            elif re.search(NATSUKI_NOU_NICKNAME_REGEX, nickname):
+                return NicknameTypes.nou
+
+            else:
+                return NicknameTypes.neutral
+
+    def get_player_nickname_type(nickname):
+        """
+        Returns the NicknameTypes type for a given string nickname for the player, defaulting to NicknameTypes.neutral
+
+        IN:
+            nickname - The nickname to test
+
+        OUT:
+            NicknameTypes type of the given nickname
+        """
+
+        if not isinstance(nickname, basestring):
+            return NicknameTypes.invalid
         
         else:
             nickname = nickname.lower().replace(" ", "")
 
-            if nickname in NICKNAME_LOVED_LIST:
-                return TYPE_LOVED
+            if re.search(PLAYER_FUNNY_NICKNAME_REGEX, nickname):
+                return NicknameTypes.funny
 
-            elif nickname in NICKNAME_DISLIKED_LIST:
-                return TYPE_DISLIKED
+            elif re.search(PLAYER_DISLIKED_NICKNAME_REGEX, nickname):
+                return NicknameTypes.disliked
 
-            elif nickname in NICKNAME_HATED_LIST:
-                return TYPE_HATED
+            elif jn_utils.get_string_contains_insult(nickname):
+                return NicknameTypes.hated
 
             elif jn_utils.get_string_contains_profanity(nickname):
-                return TYPE_PROFANITY
-
-            elif nickname in NICKNAME_FUNNY_LIST:
-                return TYPE_FUNNY
-
-            elif nickname in NICKNAME_NOU_LIST:
-                return TYPE_NOU
+                return NicknameTypes.profanity
 
             else:
-                return TYPE_NEUTRAL
+                return NicknameTypes.neutral

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -2215,7 +2215,7 @@ init 5 python:
 
 label talk_give_nickname:
     # Natsuki hasn't been nicknamed before, or is rocking her normal name
-    if persistent.jn_player_nicknames_allowed and persistent.jn_player_nicknames_current_nickname == "Natsuki":
+    if persistent._jn_nicknames_natsuki_allowed and persistent._jn_nicknames_natsuki_current_nickname == "Natsuki":
         n 1unmaj "Eh?{w=0.2} You want to give me a nickname?"
         n 1fsqsl "Why?{w=0.2} Natsuki not good enough for you?{w=0.2} Is that it?"
         extend 1fsqpu " Huh?{w=0.2} Come on, [player]!{w=0.2} Spit it out!"
@@ -2228,20 +2228,20 @@ label talk_give_nickname:
     else:
 
         # Account for strikes
-        if persistent.jn_player_nicknames_bad_given_total == 0:
+        if persistent._jn_nicknames_natsuki_bad_given_total == 0:
             n 1unmaj "Oh?{w=0.2} You wanna give me another nickname?"
             n 1uchbg "Sure,{w=0.1} why not!"
 
-        elif persistent.jn_player_nicknames_bad_given_total == 1:
+        elif persistent._jn_nicknames_natsuki_bad_given_total == 1:
             n 1unmaj "You want to give me a new nickname?"
             n 1unmbo "Alright,{w=0.1} [player]."
 
-        elif persistent.jn_player_nicknames_bad_given_total == 2:
+        elif persistent._jn_nicknames_natsuki_bad_given_total == 2:
             n 1nnmsl "Another nickname,{w=0.1} [player]?{w=0.5}{nw}"
             extend 1nllsl " Fine."
             n 1ncsaj "Just...{w=0.3} think a little about what you choose,{w=0.1} 'kay?"
 
-        elif persistent.jn_player_nicknames_bad_given_total == 3:
+        elif persistent._jn_nicknames_natsuki_bad_given_total == 3:
             n 1nnmsl "Alright,{w=0.1} [player]."
             n 1fsqpu "Just remember.{w=0.3} You've had your final warning about this."
             n 1nsqsl "Don't let me down again."
@@ -2256,7 +2256,7 @@ label talk_give_nickname:
         return
 
     else:
-        $ nickname_type = jn_nicknames.get_nickname_type(nickname)
+        $ nickname_type = jn_nicknames.get_natsuki_nickname_type(nickname)
 
     if nickname_type == jn_nicknames.NicknameTypes.invalid:
         n 1tlraj "Uhmm...{w=0.3} [player]?"
@@ -2265,8 +2265,8 @@ label talk_give_nickname:
         return
 
     elif nickname_type == jn_nicknames.NicknameTypes.loved:
-        $ persistent.jn_player_nicknames_current_nickname = nickname
-        $ n_name = persistent.jn_player_nicknames_current_nickname
+        $ persistent._jn_nicknames_natsuki_current_nickname = nickname
+        $ n_name = persistent._jn_nicknames_natsuki_current_nickname
         n 1uskgsl "O-{w=0.1}oh!{w=0.2} [player]!"
         n 1ulrunl "..."
         n 1fcsbgl "W-{w=0.1}well,{w=0.1} you have good taste,{w=0.1} at least."
@@ -2288,7 +2288,7 @@ label talk_give_nickname:
         n 1fcsfu "Why would you call me that?{w=0.5}{nw}"
         extend 1fsqfu " That's {i}awful{/i}!"
         n 1fcspu "..."
-        $ persistent.jn_player_nicknames_bad_given_total += 1
+        $ persistent._jn_nicknames_natsuki_bad_given_total += 1
 
     elif nickname_type == jn_nicknames.NicknameTypes.profanity:
         n 1fskpu "E-{w=0.1}excuse me?!"
@@ -2297,7 +2297,7 @@ label talk_give_nickname:
         n 1fslan "I seriously can't believe you,{w=0.1} [player].{w=0.5}{nw}"
         extend 1fnman " Why would you do that?{w=0.1} Are you {i}trying{/i} to get on my nerves?!"
         n 1fcspu "..."
-        $ persistent.jn_player_nicknames_bad_given_total += 1
+        $ persistent._jn_nicknames_natsuki_bad_given_total += 1
 
     elif nickname_type == jn_nicknames.NicknameTypes.funny:
         n 1nbkdv "Pffft!"
@@ -2307,8 +2307,8 @@ label talk_give_nickname:
         n 1fsgbg "[nickname] it is,{w=0.1} I guess!{w=0.5}{nw}"
         extend 1fchgn " Ehehe."
 
-        $ persistent.jn_player_nicknames_current_nickname = nickname
-        $ n_name = persistent.jn_player_nicknames_current_nickname
+        $ persistent._jn_nicknames_natsuki_current_nickname = nickname
+        $ n_name = persistent._jn_nicknames_natsuki_current_nickname
         return
 
     elif nickname_type == jn_nicknames.NicknameTypes.nou:
@@ -2356,13 +2356,13 @@ label talk_give_nickname:
 
         # Finally, assign the neutral/easter egg nickname if it was permitted by Natsuki
         if (neutral_nickname_permitted):
-            $ persistent.jn_player_nicknames_current_nickname = nickname
-            $ n_name = persistent.jn_player_nicknames_current_nickname
+            $ persistent._jn_nicknames_natsuki_current_nickname = nickname
+            $ n_name = persistent._jn_nicknames_natsuki_current_nickname
 
         return
 
     # Handle strikes
-    if persistent.jn_player_nicknames_bad_given_total == 1:
+    if persistent._jn_nicknames_natsuki_bad_given_total == 1:
         n 1kllsf "Jeez,{w=0.1} [player]...{w=0.3} that isn't like you at all!{w=0.5}{nw}"
         extend 1knmaj " What's up with you today?"
         n 1kcssl "..."
@@ -2373,7 +2373,7 @@ label talk_give_nickname:
         $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_NICKNAME)
         $ Natsuki.percentageAffinityLoss(1)
 
-    elif persistent.jn_player_nicknames_bad_given_total == 2:
+    elif persistent._jn_nicknames_natsuki_bad_given_total == 2:
         n 1fsqsl "I can't believe you did that again to me,{w=0.1} [player]."
         n 1fsqan "I told you it hurts,{w=0.1} and you went ahead anyway!"
         n 1fcsan "..."
@@ -2385,7 +2385,7 @@ label talk_give_nickname:
         $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_NICKNAME)
         $ Natsuki.percentageAffinityLoss(2.5)
 
-    elif persistent.jn_player_nicknames_bad_given_total == 3:
+    elif persistent._jn_nicknames_natsuki_bad_given_total == 3:
         n 1fsqan "You are honestly unbelievable,{w=0.1} [player]."
         n 1fnmfu "I've told you so many times now,{w=0.1} and you still won't knock it off!"
         n 1fcspu "..."
@@ -2393,7 +2393,7 @@ label talk_give_nickname:
         menu:
             n "Understand?"
 
-            "I understand. Sorry, [n_name].":
+            "I understand.":
                 n 1fsqsr "You understand,{w=0.1} do you?"
                 n 1fsqan "...Then start acting like it,{w=0.1} [player]."
                 n 1fslsl "Thanks."
@@ -2411,7 +2411,7 @@ label talk_give_nickname:
         # Apply penalty and pending apology
         $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_NICKNAME)
 
-    elif persistent.jn_player_nicknames_bad_given_total == 4:
+    elif persistent._jn_nicknames_natsuki_bad_given_total == 4:
         # Player is locked out of nicknaming; this is why we can't have nice things
         n 1fcsan "Yeah,{w=0.1} no.{w=0.2} I've heard enough.{w=0.2} I don't need to hear any more."
         n 1fnmem "When will you learn that your actions have consequences?"
@@ -2422,8 +2422,8 @@ label talk_give_nickname:
 
         # Apply affinity/trust penalties, then revoke nickname priveleges and finally apply pending apology
         $ Natsuki.percentageAffinityLoss(10)
-        $ persistent.jn_player_nicknames_allowed = False
-        $ persistent.jn_player_nicknames_current_nickname = None
+        $ persistent._jn_nicknames_natsuki_allowed = False
+        $ persistent._jn_nicknames_natsuki_current_nickname = None
         $ n_name = "Natsuki"
         $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_NICKNAME)
 
@@ -7364,5 +7364,239 @@ label talk_windup_bullying:
 
     else:
         n 1fsrpol "You owe yourself {i}that{/i} much,{w=0.1} at least."
+
+    return
+
+# Natsuki calls the player by another name, assuming they aren't blocked from asking about it
+init 5 python:
+    registerTopic(
+        Topic(
+            persistent._topic_database,
+            label="talk_player_change_name",
+            unlocked=True,
+            prompt="Can you call me something else?",
+            conditional="persistent._jn_nicknames_player_allowed",
+            category=["You"],
+            player_says=True,
+            affinity_range=(jn_affinity.ENAMORED, None),
+            location="classroom"
+        ),
+        topic_group=TOPIC_TYPE_NORMAL
+    )
+
+label talk_player_change_name:
+    # The player hasn't been nicknamed before, or is rocking their normal name
+    if persistent._jn_nicknames_player_allowed and persistent._jn_nicknames_player_current_nickname == persistent.playername:
+        n 1unmaj "Huh?{w=0.5}{nw}"
+        extend 1tnmbo " You want me to call you something else?"
+        n 1ulraj "...I mean,{w=1}{nw}"
+        extend 1tnmbo " I guess I can do that?"
+        n 1nslsslesd "It's gonna be super weird calling you something {i}other{/i} than [player],{w=0.1} though..."
+        n 1fcsbgl "Well,{w=0.1} whatever!{w=0.75}{nw}"
+        extend 1uchgn " I'm not one to judge!"
+        n 1unmbg "So..."
+        show natsuki 1uchbgl at jn_center
+
+    # Another nickname is being assigned
+    else:
+
+        # Account for strikes
+        if persistent._jn_nicknames_player_bad_given_total == 0:
+            n 1unmaj "Oh?{w=0.5}{nw}" 
+            extend 1unmbo " You wanna change your name again?"
+            n 1fchbg "Okaaay!{w=0.75}{nw}"
+            extend 1fchsml " Ehehe."
+            show natsuki 1fchbgl at jn_center
+
+        elif persistent._jn_nicknames_player_bad_given_total == 1:
+            n 1unmbo "You want me to call you something else again?{w=0.75}{nw}"
+            extend 1unmaj " Sure thing."
+            show natsuki 1unmbo at jn_center
+
+        elif persistent._jn_nicknames_player_bad_given_total == 2:
+            n 1nsqtr "This again,{w=0.1} [player]?{w=0.75}{nw}"
+            extend 1ncsaj " Alright,{w=0.1} fine."
+            n 1ncspu "Just...{w=0.3}{w=1}{nw}"
+            extend 1nsqsl " think about it properly,{w=0.1} alright?"
+            n 1nllaj "So then..."
+            show natsuki 1unmca at jn_center
+
+        elif persistent._jn_nicknames_player_bad_given_total == 3:
+            n 1fsqsr "..."
+            n 1fcsboesi "..."
+            n 1fslsl "...Fine,{w=0.1} [player]."
+            n 1fsqpu "Just keep in mind what I said {i}last time{/i}."
+            show natsuki 1nsqsl at jn_center
+
+    # Validate the nickname, respond appropriately
+    $ nickname = renpy.input(prompt="What were you thinking of,{w=0.3} [player]?", allow=jn_globals.DEFAULT_ALPHABETICAL_ALLOW_VALUES, length=10).strip()
+
+    if nickname.lower() == "nevermind":
+        n 1nnmbo "Oh.{w=1}{nw}"
+        extend 1nllpo " Well,{w=0.1} I guess that's alright...{w=1}{nw}"
+        n 1uchgn "Just means less I gotta remember!{w=0.5}{nw}"
+        extend 1fchsmelg " Ehehe."
+
+        return
+
+    else:
+        $ nickname_type = jn_nicknames.get_player_nickname_type(nickname)
+
+    if nickname_type == jn_nicknames.NicknameTypes.invalid:
+        n 1fllpu "Are...{w=1}{nw}"
+        extend 1tnmpu " you sure that's even a {i}name{/i}?"
+        n 1tlrpo "..."
+        n 1nlrss "...Yeah,{w=0.75}{nw}"
+        extend 1nsqbgsbl " I think I'll just stick with [player].{w=0.5}{nw}"
+        extend 1fchblsbr " Sorry!"
+
+        return
+
+    elif nickname_type == jn_nicknames.NicknameTypes.disliked:
+        n 1fsqemsbl "...Really,{w=0.1} [player]?{w=0.75}{nw}"
+        extend 1fnmwrsbl " Why would you even {i}suggest{/i} that?"
+        n 1flleml "You must have {i}known{/i} I wouldn't like it!"
+        n 1fcsslesi "..."
+        n 1ncspu "...Whatever.{w=1}{nw}"
+        extend 1fsrsl " Maybe you just weren't using your head enough."
+        n 1fcspu "Just...{w=0.3} {i}think{/i} a little more next time."
+        n 1knmsll "Please?"
+
+        return
+
+    elif nickname_type == jn_nicknames.NicknameTypes.hated:
+        n 1fskwrlesh "...E-{w=0.2}excuse me?!"
+        $ player_initial = jn_utils.get_player_initial()
+        n 1fnmwr "[player_initial]-{w=0.2}[player]!{w=0.75}{nw}"
+        extend 1fnmfu " That's an {b}awful{/b} name!"
+        n 1fcsan "...And I'd be even {i}more{/i} awful to use it!"
+        n 1fsqfu "{i}Not{/i} happening,{w=0.1} [player]!"
+        $ persistent._jn_nicknames_player_bad_given_total += 1
+
+    elif nickname_type == jn_nicknames.NicknameTypes.profanity:
+        n 1fscwresh "Y-{w=0.2}you said {i}what{/i} now?!{w=1}{nw}"
+        extend 1fsqfuean " I-{w=0.1}is that some kind of joke?!"
+        n 1fcssc "I am {i}not{/i} getting involved with dirt-slinging like that!"
+        n 1fcsan "And unless you want a bar of soap express-shipped to your {b}mouth{/b}..."
+        n 1fsqfu "I suggest {i}you{/i} don't either."
+        $ persistent._jn_nicknames_player_bad_given_total += 1
+
+    elif nickname_type == jn_nicknames.NicknameTypes.funny:
+        n 1fsgdv "..."
+        n 1fchgnesi "Pffffft!"
+        n 1fchbs "Come on,{w=0.3} you dork!{w=0.75}{nw}"
+        extend 1fchgnelg " Be serious,{w=0.1} will you?"
+        n 1flldvl "There's no way I'm calling you {i}that{/i}!"
+
+        return
+
+    else:
+        $ neutral_nickname_permitted = False
+
+        # A player might actually be named Natsuki, so we don't block it
+        if nickname.lower() == n_name.lower() and n_name.lower() is not "natsuki":
+            n 1nllaj "You...{w=1}{nw}" 
+            extend 1tsqbo " really {i}didn't{/i} think this one through,{w=0.1} did you?"
+            n 1tsqpueqm "Do you even know how confusing that'd be?"
+            n 1fcsbg "Nah.{w=0.5}{nw}"
+            extend 1fchgnelg " Business as usual it is!"
+
+        # Fallback for anything not categorised
+        else:
+            n 1tnmss "[nickname],{w=0.1} huh?"
+            n 1fllbo "Hmm..."
+            n 1unmbg "Well,{w=0.1} works for me!{w=0.75}{nw}"
+            extend 1uchsmeme " Consider it done,{w=0.3} [nickname]!"
+
+            if nickname.lower() == "natsuki":
+                n 1nslsssbl "...Heh."
+                n 1nsldvsbl "Natsuki."
+
+            $ neutral_nickname_permitted = True
+
+        # Finally, assign the neutral/easter egg nickname if it was permitted by Natsuki
+        if (neutral_nickname_permitted):
+            $ persistent._jn_nicknames_player_current_nickname = nickname
+            $ player = persistent._jn_nicknames_player_current_nickname
+
+        return
+
+    # Handle strikes
+    if persistent._jn_nicknames_player_bad_given_total == 1:
+        n 1fcsem "Yeesh...{w=1}{nw}"
+        extend 1tnmem " who woke {i}you{/i} up on the wrong side of the bed this morning?"
+        n 1fllsl "..."
+        n 1fcsslesi "...Look,{w=0.1} [player]."
+        n 1fnmsl " I get it.{w=0.75}{nw}"
+        extend 1flrbo " Maybe you thought you were being funny or something."
+        n 1fnmfr "Just knock it off,{w=0.1} alright?{w=1}{nw}"
+        extend 1tsqpu " Because honestly?"
+        n 1fslsl "I really {i}don't{/i} see the humour."
+
+        # Apply penalty and pending apology
+        $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_PLAYER_NAME)
+        $ Natsuki.percentageAffinityLoss(1)
+
+    elif persistent._jn_nicknames_player_bad_given_total == 2:
+        n 1fcsan "I honestly can't believe you,{w=0.1} [player].{w=1}{nw}"
+        extend 1fsqfr " Were you even {i}listening{/i} last time?{w=1}{nw}"
+        extend 1fnmem " Did you even {i}hear{/i} me?"
+        n 1fcssfesi "..."
+        n 1fsqsf "...Alright,{w=0.1} look.{w=1}{nw}"
+        extend 1fsqbo " I'm just gonna get to the point,{w=0.1} so listen up."
+        n 1fnmem "{i}Quit messing me around with this,{w=0.1} [player].{/i}"
+        n 1fcsem "You make it...{w=0.75}{nw}"
+        extend 1fcsunl " difficult...{w=0.75}{nw}"
+        extend 1fsrunl " to like you when you behave like {i}that{/i}."
+
+        # Apply penalty and pending apology
+        $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_PLAYER_NAME)
+        $ Natsuki.percentageAffinityLoss(2.5)
+
+    elif persistent._jn_nicknames_player_bad_given_total == 3:
+        n 1fcsful "You are just {i}unreal{/i},{w=0.1} [player]."
+        n 1fsqscean  "{i}How many times{/i} do I have to give you crap over this to get you to wise up?!"
+        n 1fsqwrean "Are you {i}trying{/i} to earn a smack?"
+        n 1fcsfuesi "..."
+        n 1fcsan "Well,{w=0.3} you know what?{w=1}{nw}"
+        extend 1fsqan " I'm sick of it."
+        n 1fcswr "I am {b}done{/b} giving you chances with this,{w=0.3} [player].{w=1} You're on {i}very{/i} thin ice."
+        show natsuki 1fsqfu at jn_center
+
+        menu:
+            n "Comprende?"
+
+            "I understand.":
+                n 1fsqsr "Heh.{w=0.75}{nw}"
+                extend 1fnmfr " {i}Now{/i} you understand,{w=0.1} do you?"
+                n 1fsqem "...Then {i}act{/i} like it,{w=0.1} [player]."
+
+                $ Natsuki.percentageAffinityLoss(3)
+
+            "...":
+                n 1fsqem "...Seriously,{w=0.1} [player]?{w=1}{nw}"
+                extend 1fsqsr " You're really going to act like a child about this?"
+                n 1fcsan "Quit it and {i}grow up{/i}."
+
+                $ Natsuki.percentageAffinityLoss(5)
+
+        # Apply penalty and pending apology
+        $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_PLAYER_NAME)
+
+    elif persistent._jn_nicknames_player_bad_given_total == 4:
+        # Player is locked out of nicknaming themselves
+        n 1fcsem "Heh.{w=1}{nw}"
+        extend 1fsqemean " You just {i}couldn't resist{/i},{w=1}{nw}" 
+        extend 1fsqslean " could you?"
+        n 1fcsan "I'm {b}done{/b} with you making a fool out of me with this."
+        n 1fsqfu "Don't say I didn't warn you.{w=2}{nw}"
+        extend 1fsrsr " Jerk."
+
+        # Apply affinity/trust penalties, then revoke nickname priveleges and finally apply pending apology
+        $ Natsuki.percentageAffinityLoss(10)
+        $ persistent._jn_nicknames_player_allowed = False
+        $ persistent._jn_nicknames_player_current_nickname = persistent.playername
+        $ player = persistent.playername
+        $ jn_apologies.add_new_pending_apology(jn_apologies.TYPE_BAD_PLAYER_NAME)
 
     return

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -2204,7 +2204,7 @@ init 5 python:
             label="talk_give_nickname",
             unlocked=True,
             prompt="Can I give you a nickname?",
-            conditional="persistent.jn_player_nicknames_allowed",
+            conditional="persistent._jn_nicknames_natsuki_allowed",
             category=["Natsuki"],
             player_says=True,
             affinity_range=(jn_affinity.ENAMORED, None),
@@ -2258,13 +2258,13 @@ label talk_give_nickname:
     else:
         $ nickname_type = jn_nicknames.get_nickname_type(nickname)
 
-    if nickname_type == jn_nicknames.TYPE_INVALID:
+    if nickname_type == jn_nicknames.NicknameTypes.invalid:
         n 1tlraj "Uhmm...{w=0.3} [player]?"
         n 1tnmaj "I don't think that's a nickname at all."
         n 1tllss "I'll...{w=0.3} just stick with what I have now,{w=0.1} thanks."
         return
 
-    elif nickname_type == jn_nicknames.TYPE_LOVED:
+    elif nickname_type == jn_nicknames.NicknameTypes.loved:
         $ persistent.jn_player_nicknames_current_nickname = nickname
         $ n_name = persistent.jn_player_nicknames_current_nickname
         n 1uskgsl "O-{w=0.1}oh!{w=0.2} [player]!"
@@ -2274,14 +2274,14 @@ label talk_give_nickname:
         extend 1uchsml " Ehehe."
         return
 
-    elif nickname_type == jn_nicknames.TYPE_DISLIKED:
+    elif nickname_type == jn_nicknames.NicknameTypes.disliked:
         n 1fsqbo "Come on,{w=0.1} [player]...{w=0.3} really?"
         n 1fllsl "You knew I'm not gonna be comfortable being called that."
         n 1fcssl "..."
         n 1nlraj "I'm...{w=0.3} just going to pretend you didn't say that,{w=0.1} alright?"
         return
 
-    elif nickname_type == jn_nicknames.TYPE_HATED:
+    elif nickname_type == jn_nicknames.NicknameTypes.hated:
         n 1fskem "W-{w=0.1}what?{w=0.5}{nw}"
         extend 1fscwr " What did you just call me?!"
         n 1fcsan "[player]!{w=0.2} I can't believe you!"
@@ -2290,7 +2290,7 @@ label talk_give_nickname:
         n 1fcspu "..."
         $ persistent.jn_player_nicknames_bad_given_total += 1
 
-    elif nickname_type == jn_nicknames.TYPE_PROFANITY:
+    elif nickname_type == jn_nicknames.NicknameTypes.profanity:
         n 1fskpu "E-{w=0.1}excuse me?!"
         n 1fskfu "What the hell did you just call me,{w=0.1} [player]?!"
         n 1fcsan "..."
@@ -2299,7 +2299,7 @@ label talk_give_nickname:
         n 1fcspu "..."
         $ persistent.jn_player_nicknames_bad_given_total += 1
 
-    elif nickname_type == jn_nicknames.TYPE_FUNNY:
+    elif nickname_type == jn_nicknames.NicknameTypes.funny:
         n 1nbkdv "Pffft!"
         n 1uchbselg "Ahaha!"
         n 1fbkbs "[nickname]?!{w=0.2} What was that meant to be,{w=0.1} [player]?"
@@ -2311,7 +2311,7 @@ label talk_give_nickname:
         $ n_name = persistent.jn_player_nicknames_current_nickname
         return
 
-    elif nickname_type == jn_nicknames.TYPE_NOU:
+    elif nickname_type == jn_nicknames.NicknameTypes.nou:
         n 1usqsg "No you~."
         return
 


### PR DESCRIPTION
Adds the following:
- Ability for the player to ask Natsuki to call them something else, from Enamoured upwards
- Ability for the player to apologize for asking Natsuki to call them a bad name
- Reworked Natsuki nickname to include regex instead of straight list checks
- Fixed bug where Natsuki's nickname wasn't consistently applied, particularly when launching the game after updating mod files