### PR TITLE
Docs/licence

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,139 @@
+_Just Natsuki_ is a fan work, and is unaffiliated with *Team Salvato* or any members of the *Doki Doki Literature Club* development team. *Doki Doki Literature Club* and all related characters and trademarks are property of *Team Salvato* and are used in accordance with their IP Guidlines, reproduced here:
+
+*Team Salvato's IP Guidelines for Doki Doki Literature Club, as accessed on 03/11/18, are reproduced here for convenience. For questions or an up-to-date copy of the latest terms, please visit [Team Salvato's website](http://teamsalvato.com/ip-guidelines/).*
+
+## Disclaimer
+
+These guidelines do not grant a copyright license to any DDLC-related fan content. Despite these guidelines, Team Salvato reserves the right to issue a formal takedown request for any content that infringes copyright. This includes content that uses official DDLC assets, as well as content that includes any Intellectual Properties (IPs) that belong to Team Salvato. Moreover, this page is subject to revision at any time without notice.
+
+This page was last updated: December 29th, 2022
+
+## Fan Work
+
+“Fan Work” refers to any content that includes IPs that belong to Team Salvato. The content in question includes, but is not limited to, art, music, animation, writing, videos, websites, apps, and games. The guidelines pertain to any fan work that takes place in the DDLC universe or includes characters, setting, or storyline from DDLC.
+
+There are no restrictions on how artists choose to depict the characters, setting, or events of DDLC in their fan work. We value artistic freedom and will not target fan work solely because we disagree with the content, or because it conflicts with official depictions.
+
+Physical versions of fan work may be sold locally, in limited production, by independent artists (eg. at conventions). Independent artists may also sell their fan work online if they run their own online store and manufacture/ship their own merchandise. Artists may not sell DDLC fan work by uploading the art to mass production websites that sell the art for you (eg. Redbubble).
+
+Fan work must be somehow related to the DDLC universe – you may not use Team Salvato IPs for projects that are not considered DDLC derivatives (eg. using a DDLC character to represent a website or product that isn’t itself a DDLC derivative).
+
+Businesses or companies interested in producing DDLC fan work for sale by any means other than described above should contact us for licensing or permission.
+
+Fan Work That Includes Official DDLC Assets
+Some artists choose to include assets created by Team Salvato in their fan work. These assets include, but are not limited to, any art, music, writing, or code that was included in the DDLC game or DDLC-related marketing/promotional material.
+
+Examples of fan work in this category include games, websites, videos, or music that include DDLC assets in them.
+
+Any fan work that includes official DDLC assets may NOT be sold under any circumstances, online or offline. No profit may be made from these fan works in any way, except for fan work that constitutes as Fair Use under the United States FAIR USE Act of 2007. For example, a gameplay review video or commentary video typically qualifies as Fair Use. It is the artist’s responsibility to understand Fair Use and design qualifying content.
+
+Direct upload or hosting of DDLC assets is forbidden, except when to be used as part of fan work. No profit may be made from these uploads.
+
+Fan work that includes official DDLC assets may not be used to create new video games. The exception is mods that must be patched into the official DDLC game. See the “Mods” section for more details.
+
+## Fan Games
+
+“Fan Games” refer to any fan work that is a game. This also includes new games that contain no official DDLC assets, as well as mods of the official DDLC game.
+
+You are NOT allowed to redistribute DDLC or fan games on any app store including Steam, the Google Play Store, the Apple App Store, the Windows Store, GameJolt, itch.io, or any others. You may not port DDLC or any fan game to these platforms.
+
+You may NOT create, copy, or distribute any fan game that is designed to be played in lieu of the official DDLC game. Any fan games, including mods, that “replace” DDLC, or imply that it should be played before the original, are forbidden. This includes mods that add new content to the DDLC base game, including, but not limited to, new art, new scenes, new visual effects, or voice acting. Fan games may ONLY be created with the assumption that the player has already completed the original DDLC game, and is looking for fan content.
+
+A common example is fan games that let players spend more time with the club members, possibly including new story arcs, or to satisfy the players’ desire for additional dialogue, or for a more “normal” game. These games are usually considered okay, because the only players interested in them would be those who have completed DDLC and are looking for new content. Any fan games or mods that suggest new players should play it instead of DDLC are not allowed.
+
+Fan games should not confuse the player in any way that it might be related to official DDLC content. The game should also not be mistaken for DDLC itself. This includes how the game is displayed both before and after downloading (eg. a title or download page too similar to DDLC may confuse players).
+
+Official DDLC assets may not be used in standalone games – they may only be used in mods that must be patched into the official DDLC game. See the “Mods” section for more details.
+
+Fan games must be free and may not be sold. Donation links are allowed on the website that hosts the game. However, fan games may not include any payment or donation link in the game itself, or encourage the player to donate from within the game.
+
+Fan games must state upon first run that it is a fan game unaffiliated with the official Doki Doki Literature Club. They must advise that the original game should be completed before playing, as well as provide a link to the official website where it can be downloaded (http://ddlc.moe).
+
+Below is an example disclaimer for your convenience:
+
+This is a Doki Doki Literature Club fan game that is not affiliated with Team Salvato. It is designed to be played only after the official game has been completed. You can download Doki Doki Literature Club at: http://ddlc.moe
+
+## Mods
+
+The above guidelines regarding fan games also apply to mods of the official DDLC game. A mod is any game or project whose content relies on making changes to the official DDLC game, such as adding/replacing code, art, music, writing, or other assets.
+
+Any mods must NOT be distributed as a complete game. They should contain only the files that are necessary to install the mod (usually files that are added to the DDLC game folder). Most mods only require the scripts.rpa file to be replaced – sometimes images.rpa if new graphics have been added to the game. In this example, please distribute your mod ONLY as these files, so that the user installs it into their existing official DDLC game.
+
+## Everything Else
+
+These guidelines are not necessarily exhaustive. If you wish to work on anything DDLC-related that is not covered here, or you are unsure of the specifics, then please contact us for clarification. Furthermore, please contact us if you would like to request a personal exception or a change in the guidelines, or to report a mistake on this page.
+
+Thank you for taking the time to understand the IP Guidelines. We chose to publish these guidelines not to restrict artists, but to express our desire to allow them to produce DDLC-related content. We wish to encourage artistic freedom and hope to see fans enjoy DDLC in many different ways.
+
+## Just Natsuki guidelines
+
+### Overview
+
+In general, we are open to assets and code from _Just Natsuki_ being used in other projects. However, restrictions **do** apply.
+
+All assets and code from _Just Natsuki_ **cannot be used to make a mod or fork intended as a replacement for Just Natsuki.** If you would like to add new features or content to the game, please make those contributions to the original project. We are very open to suggestions and contributions, and always consider suggestions carefully and in good faith.
+
+If, for some reason, your new features or suggestions conflict with the direction for _Just Natsuki_, you _may_ develop these privately: however, in doing so, **you agree that you forfeit your right to technical support from the _Just Natsuki_ team**.
+
+If developing your own changes to _Just Natsuki_, **you must be absolutely explicit that your work is not affiliated with the official mod effort.**
+
+Please follow Team Salvato's [IP Guidelines](http://teamsalvato.com/ip-guidelines/) for any project which includes our work.
+
+Please give credit to _Just Natsuki_ for the original work that you use and link back to our project at https://github.com/Just-Natsuki-Team/NatsukiModDev and/or website at https://justnatsuki.club/. 
+
+Do **not** claim ownership of the work others have done. Where applicable, please give individual credit for things like art assets, music and code used.
+
+Where _Just Natsuki_ has explicit permission to use assets from other projects, you may **not** use these for your own project. You **must** seek the originally credited source and obtain explicit permission from the original author(s). Permissions granted to _Just Natsuki_ by other projects do **not** automatically apply to you.
+
+When crediting _Just Natsuki_, you **must** ensure credits are **visible and explicit**, and list **all** work used. The following means of attributing credit are appropriate:
+- A special thanks on the README associated with the new work
+- A special thanks on the website associated with the new work
+
+The following means of attributing credit are **not** appropriate:
+- Credit within source code; source code is compiled and therefore credits are not visible to end users
+- Credit within a non-README document; this would not be visible on a repository without navigating to and viewing the file
+
+**When questioned about the source of _Just Natsuki_ work used, you must exercise transparency and link back to our project.**
+
+### Restrictions on work usage
+
+Further restrictions are listed below:
+
+**Art**
+
+* **All Just Natsuki art used outside of Just Natsuki must be credited back to us or the creator of said music.**
+* **All Just Natsuki art cannot be distributed or used outside of Just Natsuki without express consent from the Just Natsuki team or the creator of said art. In the event of a disagreement of consent between the Just Natsuki team and the creator of said art, the creator's consent or restriction on the usage of said art takes precedence.**
+* DDLC art used in Just Natsuki is exempt from these restrictions but is covered under Team Salvato's [IP Guidelines](http://teamsalvato.com/ip-guidelines/).
+
+**Music**
+
+* **All Just Natsuki music used outside of Just Natsuki must be credited back to us or the creator of said music.**
+* **All Just Natsuki music cannot be distributed or used outside of Just Natsuki without express consent from the Just Natsuki team or creator of said music. In the event of a disagreement of consent between the Just Natsuki team and the creator of said music, the creator's consent or restriction on the usage of said music takes precedence.**
+* Royalty-free music/sounds used in Just Natsuki are exempt from these restrictions.
+* DDLC music/sounds used in Just Natsuki are exempt from these restrictions but are covered under Team Salvato's [IP Guidelines](http://teamsalvato.com/ip-guidelines/).
+
+**Code**
+
+* **All Just Natsuki code used outside of Just Natsuki must be credited back to us.**
+* **All Just Natsuki code cannot be distributed or used outside of Just Natsuki without express consent from the Just Natsuki team.**
+* External libraries and packages (i.e: some of the libraries in the `lib` or `python-packages` folders) that are **not created by the Just Natsuki team** should not be considered "Just Natsuki code" and therefore are **exempt** from these restrictions.
+
+### Restrictions on content creation
+
+Generally, we have no qualms with content creators sharing some of the magic of _Just Natsuki_ for their viewers. However, restrictions **do** apply:
+
+- You **must** link back to our project at https://github.com/Just-Natsuki-Team/NatsukiModDev and/or website at https://justnatsuki.club/. This link **must** be prominent in the _description_ of the video, and be **clearly visible without searching**.
+- You **must not** distribute means and/or methods to cheat or bypass intended game mechanics.
+- You **must not** mislead viewers with regards to unofficial or private content. Any video featuring unofficial content **must** clearly indicate this in the _description_ of the video without the need to search or comment on the video. 
+
+## tl;dr (Plain language summary)
+
+In summary, we don't own DDLC, but Team Salvato is okay with us modifying their game as long as we don't use it to make a profit, promote it as an alternative to DDLC, or distribute this mod as a standalone game. They can change their mind on this at any time, but we don't expect they will.
+
+You **must** seek permission to use any work from _Just Natsuki_, and if granted, credit according to the guidelines above.
+
+You **must not** distribute work derived from _Just Natsuki_ that misleads players on what to expect from _Just Natsuki_.
+
+You **must not** publish content that misleads viewers on what to expect from _Just Natsuki_, or methods of cheating/bypassing mechanics.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 An After-Story style mod for Natsuki from DDLC, focusing on building a post-game relationship between Natsuki and her player (you!).
 
-**Please read this document thoroughly before downloading and installing the mod!**
+**Please read this document and the license thoroughly before downloading and installing the mod!**
 
 ### Made possible thanks to our contributors:
 <!-- readme: contributors -start -->
@@ -102,6 +102,7 @@ An After-Story style mod for Natsuki from DDLC, focusing on building a post-game
 
 ### And extra special thanks to:
 - Snow, rain graphics thanks to Monika After Story team @ https://github.com/Monika-After-Story/MonikaModDev
+- License template thanks to Monika After Story team @ https://github.com/Monika-After-Story/MonikaModDev
 - Our community, for being so patient despite our delays
 
 **You're all awesome!**


### PR DESCRIPTION
Introduces the following:
- License for use of Just Natsuki work/general usage guidelines. Based off a template from Monika After Story @ https://github.com/Monika-After-Story/MonikaModDev with permission given.
- Update README to point to license.