### PR TITLE
Bugfix/activity system linux patch

### DIFF
--- a/game/activity.rpy
+++ b/game/activity.rpy
@@ -457,13 +457,10 @@ init python in jn_activity:
                             # Try and get the parent of the window
                             focus = focus.query_tree().parent
 
-                            if isinstance(focus, int):
-                                # No parent, return
-                                return ""
-
-                            # Try and get the wm_name of the parent and return that instead
-                            wm_name = focus.get_wm_name()
-                            return wm_name if isinstance(wm_name, basestring) else ""
+                            if not isinstance(focus, int):
+                                # Try and get the wm_name of the parent and return that instead
+                                wm_name = focus.get_wm_name()
+                                return wm_name if isinstance(wm_name, basestring) else ""
 
                         elif isinstance(wm_class, tuple):
                             # Just return the parent name

--- a/game/activity.rpy
+++ b/game/activity.rpy
@@ -144,7 +144,7 @@ init python in jn_activity:
                 - JNPlayerActivity type for the active window, or None
             """
             if delay is not 0:
-                jnPause(delay, hard=True)
+                store.jnPause(delay, hard=True)
 
             window_name = getCurrentWindowName()
             if window_name is not None:
@@ -421,15 +421,21 @@ init python in jn_activity:
         """
         return getCurrentWindowName() == store.config.window_title
 
-    def getCurrentWindowName():
+    def getCurrentWindowName(delay=0):
         """
         Gets the title of the currently active window.
+
+        IN: 
+            - delay - int amount of seconds to wait before checking window
 
         OUT:
             - str representing the title of the currently active window
         """
         global ACTIVITY_SYSTEM_ENABLED 
         if ACTIVITY_SYSTEM_ENABLED:
+            if delay is not 0:
+                store.jnPause(delay, hard=True)
+
             try:
                 if renpy.windows and pygetwindow.getActiveWindow():
                     return pygetwindow.getActiveWindow().title

--- a/game/activity.rpy
+++ b/game/activity.rpy
@@ -441,13 +441,13 @@ init python in jn_activity:
                     if not isinstance(focus, int):
                         wm_name = focus.get_wm_name()
 
-                        if isinstance(wm_name, str) and wm_name != "":
+                        if isinstance(wm_name, basestring) and wm_name != "":
                             return wm_name
 
                         elif focus.get_wm_class() is None and (wm_name is None or wm_name == ""):
-                            focus = focus.query_tree.parent
-                            wm_name = window.get_wm_name()
-                            return wm_name if isinstance(wm_name, str) else ""
+                            focus = focus.query_tree().parent
+                            wm_name = focus.get_wm_name()
+                            return wm_name if isinstance(wm_name, basestring) else ""
 
                         # Fall through
 

--- a/game/activity.rpy
+++ b/game/activity.rpy
@@ -445,15 +445,28 @@ init python in jn_activity:
                     focus = Xlib.display.Display().get_input_focus().focus
 
                     if not isinstance(focus, int):
+                        # We have a window
                         wm_name = focus.get_wm_name()
 
                         if isinstance(wm_name, basestring) and wm_name != "":
+                            # Window has a name, return it
                             return wm_name
 
                         elif focus.get_wm_class() is None and (wm_name is None or wm_name == ""):
+                            # Try and get the parent of the window
                             focus = focus.query_tree().parent
+
+                            if isinstance(focus, int):
+                                # No parent, return
+                                return ""
+
+                            # Try and get the wm_name of the parent and return that instead
                             wm_name = focus.get_wm_name()
                             return wm_name if isinstance(wm_name, basestring) else ""
+
+                        elif isinstance(wm_class, tuple):
+                            # Just return the parent name
+                            return str(wm_class[0])
 
                         # Fall through
 

--- a/game/activity.rpy
+++ b/game/activity.rpy
@@ -447,12 +447,13 @@ init python in jn_activity:
                     if not isinstance(focus, int):
                         # We have a window
                         wm_name = focus.get_wm_name()
+                        wm_class = focus.get_wm_class()
 
                         if isinstance(wm_name, basestring) and wm_name != "":
                             # Window has a name, return it
                             return wm_name
 
-                        elif focus.get_wm_class() is None and (wm_name is None or wm_name == ""):
+                        elif wm_class is None and (wm_name is None or wm_name == ""):
                             # Try and get the parent of the window
                             focus = focus.query_tree().parent
 


### PR DESCRIPTION
Resolves the following issues:
- Issue where the activity system resulted in a crash for users on Linux running Wayland display sessions.
- Issue where the activity system wasn't finding any windows other than the game window, and therefore Natsuki was not responding to any player activities on X11 display sessions.