### PR TITLE
Bugfix/History lines text cutoff and gitignore update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
-game/dev/tools/dialogue.txt
-game/dev/key.txt
+game/dev/*
+game/saves/*
+game/*.rpyc

--- a/game/gui.rpy
+++ b/game/gui.rpy
@@ -367,7 +367,7 @@ define gui.history_name_xalign = 1.0
 
 ## The position, width, and alignment of the dialogue text.
 define gui.history_text_xpos = 170
-define gui.history_text_ypos = 5
+define gui.history_text_ypos = 1
 define gui.history_text_width = 740
 define gui.history_text_xalign = 0.0
 
@@ -449,7 +449,7 @@ init python:
         gui.navigation_spacing = 20
         gui.pref_button_spacing = 10
 
-        gui.history_height = 190
+        gui.history_height = 200
         gui.history_text_width = 690
 
         ## File button layout.

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -12,7 +12,7 @@
 ##
 ## The _() surrounding the string marks it as eligible for translation.
 
-define config.version = "1.1.1"
+define config.version = "1.1.2"
 define config.name = "Just Natsuki"
 define config.window_title = _("Just Natsuki - {0}".format(config.version))
 

--- a/game/screens.rpy
+++ b/game/screens.rpy
@@ -1443,7 +1443,7 @@ screen history():
         for h in _history_list:
 
             window:
-
+                
                 ## This lays things out properly if history_height is None.
                 has fixed:
                     yfit True
@@ -1462,7 +1462,6 @@ screen history():
 
         if not _history_list:
             label _("The dialogue history is empty.")
-
 
 style history_window is empty
 
@@ -1485,9 +1484,17 @@ style history_name:
     ypos gui.history_name_ypos
     xsize gui.history_name_width
 
+    line_overlap_split 8
+    line_spacing 8
+    line_leading 8
+
 style history_name_text:
     min_width gui.history_name_width
     text_align gui.history_name_xalign
+
+    line_overlap_split 8
+    line_spacing 8
+    line_leading 8
 
 style history_text:
     xpos gui.history_text_xpos
@@ -1495,14 +1502,27 @@ style history_text:
     xanchor gui.history_text_xalign
     xsize gui.history_text_width
     min_width gui.history_text_width
+
     text_align gui.history_text_xalign
     layout ("subtitle" if gui.history_text_xalign else "tex")
+
+    line_overlap_split 8
+    line_spacing 8
+    line_leading 8
 
 style history_label:
     xfill True
 
+    line_overlap_split 8
+    line_spacing 8
+    line_leading 8
+
 style history_label_text:
     xalign 0.5
+
+    line_overlap_split 8
+    line_spacing 8
+    line_leading 8
 
 ## Confirm screen ##############################################################
 ##

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -245,11 +245,6 @@ init python in jn_data_migrations:
     def to_1_0_2():
         jn_utils.log("Migration to 1.0.2 START")
         store.persistent._jn_version = "1.0.2"
-        if store.persistent.affinity >= 5000:
-            store.persistent._jn_pic_aff = store.persistent.affinity
-            store.persistent.affinity = 0
-            store.persistent._jn_pic = True
-            jn_utils.log("434346".decode("hex"))
         jn_utils.save_game()
         jn_utils.log("Migration to 1.0.2 DONE")
         return
@@ -258,11 +253,6 @@ init python in jn_data_migrations:
     def to_1_0_3():
         jn_utils.log("Migration to 1.0.3 START")
         store.persistent._jn_version = "1.0.3"
-        if store.persistent.affinity >= 5000:
-            store.persistent._jn_pic_aff = store.persistent.affinity
-            store.persistent.affinity = 0
-            store.persistent._jn_pic = True
-            jn_utils.log("434346".decode("hex"))
 
         if jn_outfits.get_outfit("jn_skater_outfit").unlocked:
             jn_outfits.get_wearable("jn_facewear_plasters").unlock()
@@ -275,11 +265,6 @@ init python in jn_data_migrations:
     def to_1_1_0():
         jn_utils.log("Migration to 1.1.0 START")
         store.persistent._jn_version = "1.1.0"
-        if store.persistent.affinity >= 5000:
-            store.persistent._jn_pic_aff = store.persistent.affinity
-            store.persistent.affinity = 0
-            store.persistent._jn_pic = True
-            jn_utils.log("434346".decode("hex"))
 
         store.persistent._event_database["event_not_ready_yet"]["conditional"] = (
             "((jn_is_time_block_early_morning() or jn_is_time_block_mid_morning()) and jn_is_weekday())"
@@ -312,6 +297,14 @@ init python in jn_data_migrations:
     def to_1_1_1():
         jn_utils.log("Migration to 1.1.1 START")
         store.persistent._jn_version = "1.1.1"
+        jn_utils.save_game()
+        jn_utils.log("Migration to 1.1.1 DONE")
+        return
+
+    @migration(["1.1.1"], "1.1.2", runtime=MigrationRuntimes.INIT)
+    def to_1_1_2():
+        jn_utils.log("Migration to 1.1.2 START")
+        store.persistent._jn_version = "1.1.2"
         if store.persistent.affinity >= 5000:
             store.persistent._jn_pic_aff = store.persistent.affinity
             store.persistent.affinity = 0
@@ -319,5 +312,5 @@ init python in jn_data_migrations:
             jn_utils.log("434346".decode("hex"))
 
         jn_utils.save_game()
-        jn_utils.log("Migration to 1.1.1 DONE")
+        jn_utils.log("Migration to 1.1.2 DONE")
         return


### PR DESCRIPTION
Resolves the following issues:

- History screen text cutoff
- Redundant migration code
- .gitignore not including `.rpyc` files