### PR TITLE
Feature/custom music on boot

### DIFF
--- a/game/custom-music.rpy
+++ b/game/custom-music.rpy
@@ -132,6 +132,9 @@ init python in jn_custom_music:
         """
         return "../{0}{1}".format(CUSTOM_MUSIC_FOLDER, file_name) if is_custom else "../{0}{1}".format(BGM_FOLDER, file_name)
 
+    if store.persistent.jn_custom_music_unlocked:
+        jn_utils.createDirectoryIfNotExists(CUSTOM_MUSIC_DIRECTORY)
+
 label music_menu:
     $ Natsuki.setInConversation(True)
     $ music_title = "Error, this should have changed"
@@ -172,7 +175,6 @@ label music_menu:
         extend 4knmajsbr " [player]?"
         n 4kslslsbr "Something {i}kinda{/i} went wrong when I was trying look for your music...{w=1}{nw}"
         extend 4kslsssbr " can you just check everything out real quick?"
-        $ folder = jn_custom_music.CUSTOM_MUSIC_DIRECTORY
         n 2tlraj "As a reminder -{w=0.5}{nw}" 
         extend 2tnmsl " anything you want me to play needs to be in the {i}custom_music{/i} folder."
         n 2fcsbgsbl "Just make sure it's all in {i}.mp3,{w=0.1} .ogg or .wav{/i} format!"

--- a/game/random_music.rpy
+++ b/game/random_music.rpy
@@ -39,19 +39,29 @@ init python in jn_random_music:
     # The file extensions we (Ren'Py) support
     _VALID_FILE_EXTENSIONS = ["mp3", "ogg", "wav"]
 
+    def getRandomMusicPlayable():
+        """
+        Returns whether random music is considered playable, ignoring if any custom music is defined.
+        Note that at least two tracks must exist for random music to work properly.
+
+        OUT:
+            - True if random music should be playable, otherwise False.
+        """
+        return (
+            store.persistent.jn_custom_music_unlocked
+            and store.persistent.jn_random_music_enabled
+            and store.Natsuki.isAffectionate(higher=True)
+            and store.preferences.get_volume("music") > 0
+            and not jn_utils.createDirectoryIfNotExists(jn_custom_music.CUSTOM_MUSIC_DIRECTORY)
+        )
+
 label random_music_change:
     $ available_custom_music = jn_utils.getAllDirectoryFiles(
         path=jn_custom_music.CUSTOM_MUSIC_DIRECTORY,
         extension_list=jn_custom_music._VALID_FILE_EXTENSIONS
     )
 
-    if not (
-        store.persistent.jn_custom_music_unlocked
-        and store.persistent.jn_random_music_enabled
-        and store.Natsuki.isAffectionate(higher=True)
-        and store.preferences.get_volume("music") > 0
-        and len(available_custom_music) >= 2
-    ):
+    if not jn_random_music.getRandomMusicPlayable() or len(available_custom_music) < 2:
         return
 
     $ track_quip = random.choice(jn_random_music._NEW_TRACK_QUIPS)

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -193,7 +193,23 @@ label ch30_init:
     show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
     hide black with Dissolve(2)
     show screen hkb_overlay
-    play music audio.just_natsuki_bgm
+
+    # Play appropriate music
+    if jn_random_music.getRandomMusicPlayable():
+        $ available_custom_music = jn_utils.getAllDirectoryFiles(
+            path=jn_custom_music.CUSTOM_MUSIC_DIRECTORY,
+            extension_list=jn_custom_music._VALID_FILE_EXTENSIONS
+        )
+        if (len(available_custom_music) >= 2):
+            $ renpy.play(
+                filename=jn_custom_music.getMusicFileRelativePath(file_name=random.choice(available_custom_music)[0], is_custom=True),
+                channel="music"
+            )
+        else:
+            play music audio.just_natsuki_bgm
+
+    else:
+        play music audio.just_natsuki_bgm
 
     # Random sticker chance
     if (

--- a/game/script-greetings.rpy
+++ b/game/script-greetings.rpy
@@ -1769,7 +1769,7 @@ init 5 python:
 label greeting_night_night_owl:
     n 1unmajesu "Oh!{w=0.3} [player]!{w=1}{nw}"
     extend 3fllsslsbl " You're a night owl too,{w=0.2} huh?"
-    n 2fcsbg "N-{w=0.2}not that I have a problem with that,{w=0.2} obviously." 
+    n 3fcsbg "N-{w=0.2}not that I have a problem with that,{w=0.2} obviously." 
     extend 4nchgnl " Welcome back!"
 
     return


### PR DESCRIPTION
Introduces the following:

- If custom music is enabled and random music is enabled, the game will now start with a random custom music track instead of the default theme.
- Sanity check for the `custom_music` on boot, creating it if it doesn't exist (and if custom music has been unlocked).

Closes #633 