### PR TITLE
Bugfix/incorrect name on birthday greet

### DIFF
--- a/game/script-events.rpy
+++ b/game/script-events.rpy
@@ -3374,7 +3374,7 @@ label holiday_player_birthday:
         jn_outfits.save_temporary_outfit(birthday_hat_outfit)
 
         jn_events.getHoliday("holiday_player_birthday").run()
-        player_name_capitalized = persistent.playername.upper()
+        player_name_capitalized = player.upper()
 
     n 1uchlgl "HAPPY BIRTHDAY,{w=0.2} [player_name_capitalized]!"
 


### PR DESCRIPTION
Resolves the following:

- Natsuki incorrectly using the player's originally given name, instead of the current name they are using (which accounts for nicknames, etc.).

Closes #647 