### PR TITLE
Bugfix/player nickname false positive

### DIFF
--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1395,7 +1395,7 @@ init -990 python in jn_globals:
         "midget",
         "moron",
         "narcissist",
-        "nasty",
+        "(^nasty$|nasty-ass)",
         "neckcrack|neck-crack",
         "necksnap|neck-snap",
         "^nimrod$",


### PR DESCRIPTION
Resolves the following:

- Bug where "Nastya" was being identified incorrectly as an insult when naming the player/Natsuki.

Closes #697 