### PR TITLE
Bugfix/unlocked outfits locked after migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://justnatsuki.club/img/logos/jn_1-2-3_logo.png" height="300"/>
+    <img src="https://justnatsuki.club/img/logos/jn_1-2-4_logo.png" height="300"/>
 </p>
 <br>
 

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -1868,6 +1868,7 @@ init -100 python in jn_utils:
             store.persistent._affinity_daily_bypasses = 5
 
         if store.persistent.affinity >= (store.persistent._jn_gs_aff + 250):
+            store.persistent._jn_pic_aff = store.persistent.affinity
             store.persistent.affinity = store.persistent._jn_gs_aff
             jn_utils.log("434346".decode("hex"))
             store.persistent._jn_pic = True

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -12,7 +12,7 @@
 ##
 ## The _() surrounding the string marks it as eligible for translation.
 
-define config.version = "1.2.3"
+define config.version = "1.2.4"
 define config.name = "Just Natsuki"
 define config.window_title = _("Just Natsuki - {0}".format(config.version))
 

--- a/game/outfits.rpy
+++ b/game/outfits.rpy
@@ -589,6 +589,9 @@ init -1 python in jn_outfits:
                 if not "jn_" in outfit.reference_name and not player_created:
                     _SESSION_NEW_UNLOCKS.append(outfit)
 
+            else:
+                outfit.__load()
+
     def __register_wearable(wearable):
         """
         Registers a new wearable in the list of all wearables, allowing in-game access and persistency.

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -245,7 +245,6 @@ init python in jn_data_migrations:
     def to_1_0_2():
         jn_utils.log("Migration to 1.0.2 START")
         store.persistent._jn_version = "1.0.2"
-        jn_utils.save_game()
         jn_utils.log("Migration to 1.0.2 DONE")
         return
 
@@ -297,7 +296,6 @@ init python in jn_data_migrations:
     def to_1_1_1():
         jn_utils.log("Migration to 1.1.1 START")
         store.persistent._jn_version = "1.1.1"
-        jn_utils.save_game()
         jn_utils.log("Migration to 1.1.1 DONE")
         return
 
@@ -317,7 +315,6 @@ init python in jn_data_migrations:
     def to_1_2_1():
         jn_utils.log("Migration to 1.2.1 START")
         store.persistent._jn_version = "1.2.1"
-        jn_utils.save_game()
         jn_utils.log("Migration to 1.2.1 DONE")
         return
 
@@ -325,7 +322,6 @@ init python in jn_data_migrations:
     def to_1_2_2():
         jn_utils.log("Migration to 1.2.2 START")
         store.persistent._jn_version = "1.2.2"
-        jn_utils.save_game()
         jn_utils.log("Migration to 1.2.2 DONE")
         return
 
@@ -333,13 +329,58 @@ init python in jn_data_migrations:
     def to_1_2_3():
         jn_utils.log("Migration to 1.2.3 START")
         store.persistent._jn_version = "1.2.3"
+        jn_utils.log("Migration to 1.2.3 DONE")
+        return
 
-        if store.persistent.affinity >= 7500:
+    @migration(["1.2.3"], "1.2.4", runtime=MigrationRuntimes.INIT)
+    def to_1_2_4():
+        jn_utils.log("Migration to 1.2.4 START")
+        store.persistent._jn_version = "1.2.4"
+
+        if "holiday_christmas_day" in store.persistent._seen_ever:
+            jn_outfits.get_outfit("jn_christmas_outfit").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_christmas_outfit")
+
+        if "talk_are_you_into_cosplay" in store.persistent._seen_ever and store.Natsuki.isAffectionate(higher=True):
+            jn_outfits.get_outfit("jn_trainer_cosplay").unlock()
+            jn_outfits.get_outfit("jn_sango_cosplay").unlock()
+            jn_utils.log("Unlock state corrected for outfits: jn_trainer_cosplay, jn_sango_cosplay")
+
+        if "talk_skateboarding" in store.persistent._seen_ever and store.Natsuki.isAffectionate(higher=True):
+            jn_outfits.get_outfit("jn_skater_outfit").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_skater_outfit")
+
+        if "event_warm_package" in store.persistent._seen_ever:
+            jn_outfits.get_outfit("jn_cosy_cardigan_outfit").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_cosy_cardigan_outfit")
+
+        if "talk_fitting_clothing" in store.persistent._seen_ever:
+            jn_outfits.get_outfit("jn_pastel_goth_getup").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_pastel_goth_getup")
+
+        if "holiday_valentines_day" in store.persistent._seen_ever:
+            jn_outfits.get_outfit("jn_ruffle_neck_sweater_outfit").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_ruffle_neck_sweater_outfit")
+
+            if store.Natsuki.isLove(higher=True):
+                jn_outfits.get_outfit("jn_heart_sweater_outfit").unlock()
+                jn_utils.log("Unlock state corrected for outfit: jn_heart_sweater_outfit")
+
+        if "talk_chocolate_preference" in store.persistent._seen_ever and store.Natsuki.isAffectionate(higher=True):
+            jn_outfits.get_outfit("jn_chocolate_plaid_collection").unlock()
+            jn_utils.log("Unlock state corrected for outfit: jn_chocolate_plaid_collection")
+
+        if "holiday_easter" in store.persistent._seen_ever:
+            jn_outfits.get_outfit("jn_chick_outfit").unlock()
+            jn_outfits.get_outfit("jn_cherry_blossom_outfit").unlock()
+            jn_utils.log("Unlock state corrected for outfits: jn_chick_outfit, jn_cherry_blossom_outfit")
+
+        if store.persistent.affinity >= 12500:
             store.persistent._jn_pic_aff = store.persistent.affinity
             store.persistent.affinity = 0
             store.persistent._jn_pic = True
             jn_utils.log("434346".decode("hex"))
 
         jn_utils.save_game()
-        jn_utils.log("Migration to 1.2.3 DONE")
+        jn_utils.log("Migration to 1.2.4 DONE")
         return


### PR DESCRIPTION
Resolves the following:

- Issue where previously unlocked outfits were locked again after progressing through the migration process, leaving the constituent wearables unlocked but preventing the outfits themselves being listed in the outfit selection menu; affected all unlockable official JN outfits (but not official extra outfits or custom outfits)
- Outfits affected by the above will be unlocked automatically if the player meets the unlock criteria

Introduces the following:

- Updated version to `1.2.4`
- Updated documentatation