### PR TITLE
Bugfix/Renpy for dummies clone

### DIFF
--- a/game/desk-items.rpy
+++ b/game/desk-items.rpy
@@ -237,6 +237,14 @@ init -55 python in jn_desk_items:
     ))
 
     __registerDeskItem(JNDeskItem(
+        reference_name="jn_renpy_for_dummies_held",
+        item_type=JNDeskItemTypes.normal,
+        desk_slot=JNDeskSlots.centre,
+        unlocked=False,
+        image_path="mod_assets/props/renpy_for_dummies_book_held.png"
+    ))
+
+    __registerDeskItem(JNDeskItem(
         reference_name="jn_renpy_for_dummies_closed",
         item_type=JNDeskItemTypes.normal,
         desk_slot=JNDeskSlots.left,

--- a/game/script-events.rpy
+++ b/game/script-events.rpy
@@ -40,7 +40,6 @@ transform jn_confetti_fall:
 # Foreground props are displayed on the desk, in front of Natsuki
 image prop poetry_attempt = "mod_assets/props/poetry_attempt.png"
 image prop math_attempt = "mod_assets/props/math_attempt.png"
-image prop renpy_for_dummies_book_held = "mod_assets/props/renpy_for_dummies_book_held.png"
 image prop a_la_mode_manga_held = "mod_assets/props/a_la_mode_manga_held.png"
 image prop strawberry_milkshake = "mod_assets/props/strawberry_milkshake.png"
 image prop step_by_step_manga_held = "mod_assets/props/step_by_step_manga_held.png"
@@ -1120,7 +1119,7 @@ label event_renpy_for_dummies:
         "Enter...":
             pass
 
-    show prop renpy_for_dummies_book_held zorder JN_PROP_ZORDER
+    $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_held"))
     $ jn_events.displayVisuals("1fcspo")
     $ jn_globals.force_quit_enabled = True
 
@@ -1136,7 +1135,7 @@ label event_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
     $ jnPause(2)
     play audio drawer
-    hide prop renpy_for_dummies_book_held
+    $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.centre)
     show natsuki 4nslsr
     $ jnPause(4)
     hide black with Dissolve(1)

--- a/game/script-idles.rpy
+++ b/game/script-idles.rpy
@@ -278,8 +278,8 @@ label idle_twitch_playing:
 label idle_reading_parfait_girls:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
 
-    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.left) == "jn_parfait_manga_closed":
-        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.left)
+    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.right) == "jn_parfait_manga_closed":
+        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.right)
 
     $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_parfait_manga_held"))
     $ Natsuki.setIsReadingToRight(True)
@@ -320,10 +320,14 @@ label idle_reading_parfait_girls:
 
 label idle_reading_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
-    show prop renpy_for_dummies_book_held zorder JN_PROP_ZORDER
+
+    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.left) == "jn_renpy_for_dummies_closed":
+        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.left)
+
+    $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_held"))
+    $ Natsuki.setIsReadingToRight(True)
     show natsuki reading
     hide black with Dissolve(0.5)
-    $ Natsuki.setIsReadingToRight(True)
     $ jnClickToContinue(silent=False)
 
     n 1fdwbo "...{w=1}{nw}"
@@ -344,9 +348,17 @@ label idle_reading_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
     $ jnPause(0.5)
     show natsuki 1fcssmeme
-    hide prop
-    play audio drawer
-    $ jnPause(1.3)
+    $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.centre)
+
+    if random.choice([True, False]):
+        play audio drawer
+        $ jnPause(1.3)
+    
+    else:
+        play audio book_closing
+        $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_closed"))
+        $ jnPause(0.3)
+
     hide black with Dissolve(0.5)
     $ jnPause(1)
 


### PR DESCRIPTION
Resolves the following:

- Fixes instances where the Ren'Py for dummies book could appear both on the desk and being read by Natsuki at the same time
- Fixes instances where the Parfait Girls book could appear both on the desk and being read by Natsuki at the same time
- Ren'Py for dummies book is now a desk item