### PR TITLE
v1.3.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
-    <img src="https://justnatsuki.club/img/logos/jn_1-3-1_logo.png" height="300"/>
+    <img src="https://justnatsuki.club/img/logos/jn_1-3-2_logo.png" height="300"/>
 </p>
 <br>
 

--- a/game/desk-items.rpy
+++ b/game/desk-items.rpy
@@ -237,6 +237,14 @@ init -55 python in jn_desk_items:
     ))
 
     __registerDeskItem(JNDeskItem(
+        reference_name="jn_renpy_for_dummies_held",
+        item_type=JNDeskItemTypes.normal,
+        desk_slot=JNDeskSlots.centre,
+        unlocked=False,
+        image_path="mod_assets/props/renpy_for_dummies_book_held.png"
+    ))
+
+    __registerDeskItem(JNDeskItem(
         reference_name="jn_renpy_for_dummies_closed",
         item_type=JNDeskItemTypes.normal,
         desk_slot=JNDeskSlots.left,

--- a/game/options.rpy
+++ b/game/options.rpy
@@ -12,7 +12,7 @@
 ##
 ## The _() surrounding the string marks it as eligible for translation.
 
-define config.version = "1.3.1"
+define config.version = "1.3.2"
 define config.name = "Just Natsuki"
 define config.window_title = _("Just Natsuki - {0}".format(config.version))
 

--- a/game/script-blackjack.rpy
+++ b/game/script-blackjack.rpy
@@ -807,7 +807,8 @@ label blackjack_quit_forfeit:
         
         $ natsuki_prompt = "You can at {i}least{/i} stick it out to the end of this one,{w=0.2} right?"
         show natsuki option_wait_smug
-        
+    
+    $ natsuki_prompt = renpy.substitute(natsuki_prompt)
     menu:
         n  "[natsuki_prompt]"
 
@@ -839,7 +840,7 @@ label blackjack_quit_forfeit:
                 extend 4tlrbo " Huh."
                 n 2tlrsl "..."
                 n 2ulrfl "Well.{w=0.75}{nw}"
-                extend 2fcsss " looks like {i}you{/i} know what they say at least,{w=0.5}{nw}" 
+                extend 2fcsss " Looks like {i}you{/i} know what they say at least,{w=0.5}{nw}" 
                 extend 2fsqbg " [player]."
                 n 6fcsbs "Guess the only winning move for you was not to play!{w=0.75}{nw}"
                 extend 7fchsmeme " Ehehe."

--- a/game/script-events.rpy
+++ b/game/script-events.rpy
@@ -40,7 +40,6 @@ transform jn_confetti_fall:
 # Foreground props are displayed on the desk, in front of Natsuki
 image prop poetry_attempt = "mod_assets/props/poetry_attempt.png"
 image prop math_attempt = "mod_assets/props/math_attempt.png"
-image prop renpy_for_dummies_book_held = "mod_assets/props/renpy_for_dummies_book_held.png"
 image prop a_la_mode_manga_held = "mod_assets/props/a_la_mode_manga_held.png"
 image prop strawberry_milkshake = "mod_assets/props/strawberry_milkshake.png"
 image prop step_by_step_manga_held = "mod_assets/props/step_by_step_manga_held.png"
@@ -1120,7 +1119,7 @@ label event_renpy_for_dummies:
         "Enter...":
             pass
 
-    show prop renpy_for_dummies_book_held zorder JN_PROP_ZORDER
+    $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_held"))
     $ jn_events.displayVisuals("1fcspo")
     $ jn_globals.force_quit_enabled = True
 
@@ -1136,7 +1135,7 @@ label event_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
     $ jnPause(2)
     play audio drawer
-    hide prop renpy_for_dummies_book_held
+    $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.centre)
     show natsuki 4nslsr
     $ jnPause(4)
     hide black with Dissolve(1)

--- a/game/script-idles.rpy
+++ b/game/script-idles.rpy
@@ -278,8 +278,8 @@ label idle_twitch_playing:
 label idle_reading_parfait_girls:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
 
-    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.left) == "jn_parfait_manga_closed":
-        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.left)
+    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.right) == "jn_parfait_manga_closed":
+        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.right)
 
     $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_parfait_manga_held"))
     $ Natsuki.setIsReadingToRight(True)
@@ -320,10 +320,14 @@ label idle_reading_parfait_girls:
 
 label idle_reading_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
-    show prop renpy_for_dummies_book_held zorder JN_PROP_ZORDER
+
+    if Natsuki.getDeskItemReferenceName(jn_desk_items.JNDeskSlots.left) == "jn_renpy_for_dummies_closed":
+        $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.left)
+
+    $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_held"))
+    $ Natsuki.setIsReadingToRight(True)
     show natsuki reading
     hide black with Dissolve(0.5)
-    $ Natsuki.setIsReadingToRight(True)
     $ jnClickToContinue(silent=False)
 
     n 1fdwbo "...{w=1}{nw}"
@@ -344,9 +348,17 @@ label idle_reading_renpy_for_dummies:
     show black zorder JN_BLACK_ZORDER with Dissolve(0.5)
     $ jnPause(0.5)
     show natsuki 1fcssmeme
-    hide prop
-    play audio drawer
-    $ jnPause(1.3)
+    $ Natsuki.clearDeskItem(jn_desk_items.JNDeskSlots.centre)
+
+    if random.choice([True, False]):
+        play audio drawer
+        $ jnPause(1.3)
+    
+    else:
+        play audio book_closing
+        $ Natsuki.setDeskItem(jn_desk_items.getDeskItem("jn_renpy_for_dummies_closed"))
+        $ jnPause(0.3)
+
     hide black with Dissolve(0.5)
     $ jnPause(1)
 

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -11794,7 +11794,7 @@ label talk_windup_playing_things_out_loud:
         n 2fcsemesi "..."
         n 2fllaj "When you're taking some sort of public transport,{w=0.2} or you're just hanging around somewhere.{w=0.75}{nw}"
         extend 2fllfl " That kind of thing."
-        n 4fcsanean "...And then some total jerk feels the need to pull our their phone just to blast out what {i}they{/i} feel like listening to."
+        n 4fcsanean "...And then some total jerk feels the need to pull out their phone just to blast out what {i}they{/i} feel like listening to."
         n 4fsrsl "..."
         n 2fnmwrl "H-{w=0.2}hey!{w=0.75}{nw}"
         extend 2fcspol " I'm being serious here,{w=0.2} [player]!{w=0.75}{nw}"

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -7847,7 +7847,7 @@ label talk_thoughts_on_tea:
         "I prefer tea.":
             if player_tea_coffee_preference_known:
                 if persistent.jn_player_tea_coffee_preference == "tea":
-                    n 1nnmss "2tnmss,{w=0.5}{nw}"
+                    n 1nnmss "Well,{w=0.5}{nw}"
                     extend 1tnmss " some things never change,{w=0.2} huh?"
                     n 1fchsm "Ehehe."
 

--- a/game/zz_data-migrations.rpy
+++ b/game/zz_data-migrations.rpy
@@ -444,9 +444,17 @@ init python in jn_data_migrations:
         return
 
     @migration(["1.3.0"], "1.3.1", runtime=MigrationRuntimes.INIT)
-    def to_1_3_0():
+    def to_1_3_1():
         jn_utils.log("Migration to 1.3.1 START")
         store.persistent._jn_version = "1.3.1"
+        jn_utils.save_game()
+        jn_utils.log("Migration to 1.3.1 DONE")
+        return
+
+    @migration(["1.3.1"], "1.3.2", runtime=MigrationRuntimes.INIT)
+    def to_1_3_2():
+        jn_utils.log("Migration to 1.3.2 START")
+        store.persistent._jn_version = "1.3.2"
 
         if store.persistent.affinity >= 7500:
             store.persistent._jn_pic_aff = store.persistent.affinity
@@ -455,5 +463,5 @@ init python in jn_data_migrations:
             jn_utils.log("434346".decode("hex"))
 
         jn_utils.save_game()
-        jn_utils.log("Migration to 1.3.1 DONE")
+        jn_utils.log("Migration to 1.3.2 DONE")
         return


### PR DESCRIPTION
Resolves the following:

_Bugs fixed:_

- Fixed a typo in the `talk_windup_playing_things_out_loud` topic
- Fixed a typo in the `talk_thoughts_on_tea` topic
- Fixed a bug where multiple copies of the Ren'Py for Dummies and Parfait Girls books could be seen at once
- Fixed a bug where `[player]` was used to refer to the player instead of the player's actual name on a particular Blackjack line
- Fixed a bug where the required library for web-based activity was not supplied, resulting in errors when the game checked for updates, etc.

