### PR TITLE
Bugfix/improved quit handling

### DIFF
--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -2070,6 +2070,9 @@ init -999 python:
             if renpy.get_screen(blocked_screen):
                 return
 
+        if jn_globals.current_label == "try_force_quit":
+            return
+
         if jn_globals.force_quit_enabled:
             renpy.call("try_force_quit")
 

--- a/game/definitions.rpy
+++ b/game/definitions.rpy
@@ -2048,32 +2048,45 @@ init python:
     player = persistent.playername
 
 init -999 python:
-    def label_callback(name, abnormal):
+    def labelCallback(name, abnormal):
         jn_globals.last_label = jn_globals.current_label
         jn_globals.current_label = name
 
-    config.label_callback = label_callback
+    config.label_callback = labelCallback
 
-    def quit_input_check():
+    def quitInputCheck():
         """
-        This checks to ensure an input or menu screen is not up before allowing a force quit, as these crash the game. Thanks, Tom.
+        Checks to ensure that a screen/label isn't up that crashes the game, interferes or otherwise doesn't work with the force quit mechanics/dialogue.
+        If so, then prevents the force quit process from continuing until that screen/label is hidden, or the player quits in a way we can't control (I.E spamming the close button or task manager).
         """
-        blocked_screens = (
+        for blocked_screen in (
             "input",
             "choice",
+            "choice_centred",
+            "choice_centred_mute",
+            "categorized_menu",
+            "scrollable_choice_menu",
             "poem_view",
             "preferences",
             "history",
-            "hotkeys"
-        )
-        for blocked_screen in blocked_screens:
+            "hotkeys",
+            "create_outfit",
+            "snap_ui",
+            "blackjack_ui"
+        ):
             if renpy.get_screen(blocked_screen):
+                Natsuki.setForceQuitAttempt(True)
+                Natsuki.addApology(jn_apologies.ApologyTypes.sudden_leave)
+                Natsuki.setQuitApology(jn_apologies.ApologyTypes.sudden_leave)
                 return
 
-        if jn_globals.current_label == "try_force_quit":
+        if jn_globals.current_label in (
+            "try_force_quit"
+        ):
+            # Prevent the dialogue being called again if a force quit is already in progress
             return
 
-        if jn_globals.force_quit_enabled:
+        elif jn_globals.force_quit_enabled:
             renpy.call("try_force_quit")
 
     class JNEvent(object):

--- a/game/natsuki.rpy
+++ b/game/natsuki.rpy
@@ -776,6 +776,13 @@ init 0 python:
             store.persistent._jn_player_apology_type_on_quit = int(apology_type)
 
         @staticmethod
+        def clearQuitApology():
+            """
+            Clears the quit apology type to be checked on loading the game after quitting.
+            """
+            store.persistent._jn_player_apology_type_on_quit = None
+
+        @staticmethod
         def removeApology(apology_type):
             """
             Removes an apology from the list of pending apologies, if it exists.

--- a/game/natsuki.rpy
+++ b/game/natsuki.rpy
@@ -87,6 +87,9 @@ init 0 python:
         # We have to cater for both since Natsuki owns books that read both ways
         _is_reading_to_right = False
 
+        # The force quit state; used for some extra handling of consequences around force quits
+        _is_force_quit_attempt = None
+
         @staticmethod
         def setDeskItem(item, desk_slot=None):
             """
@@ -748,6 +751,24 @@ init 0 python:
         # START: Dialogue functionality
 
         @staticmethod
+        def getForceQuitAttempt():
+            """
+            Gets the force quit attempt state.
+            If True, the player attempted a force quit in this session that wasn't backed out of.
+            """
+            return Natsuki._is_force_quit_attempt
+        
+        @staticmethod
+        def setForceQuitAttempt(force_quit):
+            """
+            Sets the force quit attempt state.
+
+            IN:
+                - force_quit - The bool force quit attempt state to set
+            """
+            Natsuki._is_force_quit_attempt = force_quit
+
+        @staticmethod
         def addApology(apology_type):
             """
             Adds a new apology possiblity to the list of pending apologies.
@@ -761,6 +782,13 @@ init 0 python:
 
             if not int(apology_type) in store.persistent._jn_player_pending_apologies:
                 store.persistent._jn_player_pending_apologies.append(int(apology_type))
+
+        @staticmethod
+        def getQuitApology():
+            """
+            Gets the jn_apologies.ApologyTypes type to be checked on loading the game after quitting, or None if not set.
+            """
+            return jn_apologies.ApologyTypes(store.persistent._jn_player_apology_type_on_quit) if store.persistent._jn_player_apology_type_on_quit is not None else None
 
         @staticmethod
         def setQuitApology(apology_type):

--- a/game/script-admissions.rpy
+++ b/game/script-admissions.rpy
@@ -29,7 +29,7 @@ init 0 python in jn_admissions:
     # The last admission the player gave to Natsuki
     last_admission_type = None
 
-    def get_all_admissions():
+    def getAllAdmissions():
         """
         Gets all admission topics which are available
 
@@ -46,7 +46,7 @@ label player_admissions_start:
     python:
         admission_menu_items = [
             (_admission.prompt, _admission.label)
-            for _admission in jn_admissions.get_all_admissions()
+            for _admission in jn_admissions.getAllAdmissions()
         ]
         admission_menu_items.sort()
 
@@ -1314,6 +1314,7 @@ label admission_tired:
 
         $ persistent.jn_player_admission_type_on_quit = jn_admissions.TYPE_TIRED
         $ persistent._jn_player_admission_forced_leave_date = datetime.datetime.now()
+        $ Natsuki.setForceQuitAttempt(False)
         
         return { "quit": None }
 
@@ -1340,6 +1341,7 @@ label admission_tired:
 
         # Add pending apology
         $ Natsuki.addApology(jn_apologies.ApologyTypes.unhealthy)
+        $ Natsuki.setForceQuitAttempt(False)
         $ persistent.jn_player_admission_type_on_quit = jn_admissions.TYPE_SICK
         $ persistent._jn_player_admission_forced_leave_date = datetime.datetime.now()
 
@@ -1385,6 +1387,7 @@ label admission_tired:
 
         # Add pending apology
         $ Natsuki.addApology(jn_apologies.ApologyTypes.unhealthy)
+        $ Natsuki.setForceQuitAttempt(False)
         $ persistent.jn_player_admission_type_on_quit = jn_admissions.TYPE_TIRED
         $ persistent._jn_player_admission_forced_leave_date = datetime.datetime.now()
 

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -829,6 +829,9 @@ label try_force_quit:
         $ renpy.jump("quit")
 
     else:
+        $ Natsuki.addApology(jn_apologies.ApologyTypes.sudden_leave)
+        $ Natsuki.setQuitApology(jn_apologies.ApologyTypes.sudden_leave)
+
         # Standard quit behaviour
         if Natsuki.isAffectionate(higher=True):
             n 2ccsem "W-{w=0.2}wait,{w=0.5}{nw}" 
@@ -868,6 +871,9 @@ label try_force_quit:
                 else:
                     n 1fcsfr "Whatever.{w=1}{nw}"
                     n 2fsqsl "{cps=\7.5}As I was saying.{/cps}{w=1}{nw}"
+
+                $ Natsuki.removeApology(jn_apologies.ApologyTypes.sudden_leave)
+                $ Natsuki.clearQuitApology()
 
                 return
 
@@ -914,8 +920,6 @@ label try_force_quit:
                 # Apply consequences for force quitting, then glitch quit out
                 python:
                     Natsuki.percentageAffinityLoss(2)
-                    Natsuki.addApology(jn_apologies.ApologyTypes.sudden_leave)
-                    Natsuki.setQuitApology(jn_apologies.ApologyTypes.sudden_leave)
 
                 play audio static
                 show glitch_garbled_b zorder JN_GLITCH_ZORDER with hpunch

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -90,7 +90,7 @@ label ch30_init:
             Natsuki.setQuitApology(jn_apologies.ApologyTypes.prolonged_leave)
 
         # Repeat visits have a small affinity gain
-        elif not persistent._jn_player_apology_type_on_quit and datetime.date.today().day != persistent.jn_last_visited_date.day:
+        elif not Natsuki.getQuitApology() and datetime.date.today().day != persistent.jn_last_visited_date.day:
             Natsuki.calculatedAffinityGain()
 
         # If we have decorations from the last holiday, and the day hasn't changed, then we should put them back up
@@ -186,7 +186,7 @@ label ch30_init:
         elif not jn_topic_in_event_list_pattern("^greeting_"):
             if (
                 random.randint(1, 10) == 1
-                and (not persistent._jn_player_admission_type_on_quit and not persistent._jn_player_apology_type_on_quit)
+                and (not persistent._jn_player_admission_type_on_quit and not Natsuki.getQuitApology())
                 and jn_events.selectEvent()
             ):
                 push(jn_events.selectEvent())
@@ -209,7 +209,7 @@ label ch30_init:
                     renpy.show("natsuki idle", at_list=[jn_center], zorder=JN_NATSUKI_ZORDER)
 
                 persistent._jn_player_admission_type_on_quit = None
-                persistent._jn_player_apology_type_on_quit = None
+                Natsuki.clearQuitApology()
 
     # Prepare visuals
     $ jnPause(0.1)
@@ -270,6 +270,7 @@ label ch30_loop:
             LAST_DAY_CHECK = _now.day
             day_check()
 
+        Natsuki.setForceQuitAttempt(False)
         Natsuki.setInConversation(False)
 
     #Now, as long as there's something in the queue, we should go for it
@@ -760,11 +761,12 @@ label player_select_topic(is_repeat_topics=False):
 label farewell_menu:
     python:
         # Sort the farewell options by their display name
-        available_farewell_options = jn_farewells.get_farewell_options()
+        available_farewell_options = jn_farewells.getFarewellOptions()
         available_farewell_options.sort(key = lambda option: option[0])
         available_farewell_options.append(("Goodbye.", "farewell_start"))
 
     call screen scrollable_choice_menu(available_farewell_options, ("Nevermind.", None))
+    $ Natsuki.setForceQuitAttempt(False)
 
     if isinstance(_return, basestring):
         show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
@@ -811,6 +813,8 @@ label extras_menu:
     jump ch30_loop
 
 label try_force_quit:
+    $ Natsuki.setInConversation(True)
+
     # Goodnight
     if persistent._jn_player_tt_state >= 2 or persistent._jn_pic:
         $ renpy.jump("quit")
@@ -821,14 +825,17 @@ label try_force_quit:
         and jn_farewells.JNForceQuitStates(persistent.jn_player_force_quit_state) == jn_farewells.JNForceQuitStates.not_force_quit
     ):
         # Player hasn't force quit before, special dialogue
+        $ Natsuki.setForceQuitAttempt(False)
         $ push("farewell_force_quit")
         $ renpy.jump("call_next_topic")
 
     elif not jn_introduction.JNIntroductionStates(persistent.jn_introduction_state) == jn_introduction.JNIntroductionStates.complete:
         # Player hasn't passed the intro sequence, just quit
+        $ Natsuki.setForceQuitAttempt(False)
         $ renpy.jump("quit")
 
     else:
+        $ Natsuki.setForceQuitAttempt(True)
         $ Natsuki.addApology(jn_apologies.ApologyTypes.sudden_leave)
         $ Natsuki.setQuitApology(jn_apologies.ApologyTypes.sudden_leave)
 
@@ -872,6 +879,7 @@ label try_force_quit:
                     n 1fcsfr "Whatever.{w=1}{nw}"
                     n 2fsqsl "{cps=\7.5}As I was saying.{/cps}{w=1}{nw}"
 
+                $ Natsuki.setForceQuitAttempt(False)
                 $ Natsuki.removeApology(jn_apologies.ApologyTypes.sudden_leave)
                 $ Natsuki.clearQuitApology()
 
@@ -916,10 +924,6 @@ label try_force_quit:
                         $ jnPause(0.025, hard=True)
                         hide glitch_garbled_n
                         hide glitch_garbled_red
-
-                # Apply consequences for force quitting, then glitch quit out
-                python:
-                    Natsuki.percentageAffinityLoss(2)
 
                 play audio static
                 show glitch_garbled_b zorder JN_GLITCH_ZORDER with hpunch

--- a/game/script-farewells.rpy
+++ b/game/script-farewells.rpy
@@ -52,7 +52,7 @@ init python in jn_farewells:
         def __int__(self):
             return self.value
 
-    def get_farewell_options():
+    def getFarewellOptions():
         """
         Returns the list of all farewell options when saying Goodbye to Natsuki.
         """
@@ -69,7 +69,7 @@ init python in jn_farewells:
             ("I'm going away for a while.", "farewell_option_extended_leave")
         ]
 
-    def select_farewell():
+    def selectFarewell():
         """
         Picks a random farewell, accounting for affinity
         If the player has already been asked to stay by Natsuki, a farewell without the option
@@ -90,7 +90,8 @@ init python in jn_farewells:
         return random.choice(farewell_pool).label
 
 label farewell_start:
-    $ push(jn_farewells.select_farewell())
+    $ Natsuki.setForceQuitAttempt(False)
+    $ push(jn_farewells.selectFarewell())
     jump call_next_topic
 
 # Only chosen for the first time the player chooses to say Goodbye

--- a/game/script-greetings.rpy
+++ b/game/script-greetings.rpy
@@ -32,7 +32,7 @@ init python in jn_greetings:
         kwargs = dict()
 
         # The player either left suddenly, or has been gone a long time
-        if store.persistent._jn_player_apology_type_on_quit is not None:
+        if store.Natsuki.getQuitApology() is not None:
             kwargs.update({"additional_properties": [("apology_type", jn_apologies.ApologyTypes(store.persistent._jn_player_apology_type_on_quit))]})
 
         # The player left or was forced to leave by way of an admission (E.G tired, sick)
@@ -686,6 +686,7 @@ label greeting_tt_warning:
         show glitch_garbled_c zorder JN_GLITCH_ZORDER with vpunch
         hide glitch_garbled_c
         $ Natsuki.percentageAffinityLoss(10)
+        $ Natsuki.setForceQuitAttempt(False)
 
         return { "quit": None }
 
@@ -2104,6 +2105,7 @@ init 5 python:
     )
 
 label greeting_sudden_leave:
+    $ Natsuki.percentageAffinityLoss(2)
     if Natsuki.isEnamored(higher=True):
         n 4kwmsrl "..."
         n 4kwmsrl "[player]."

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -4022,8 +4022,11 @@ label talk_i_love_you:
             n 1fcsantsd "..."
             n 1fsqfutse "Go!"
             n 4fscsctdc "{i}JUST LEAVE ME ALONE!{/i}{nw}"
+            
             $ Natsuki.percentageAffinityLoss(25)
+            $ Natsuki.setForceQuitAttempt(False)
             $ persistent.jn_player_love_you_count += 1
+
             return { "quit": None }
 
         $ persistent.jn_player_love_you_count += 1

--- a/game/splash.rpy
+++ b/game/splash.rpy
@@ -227,6 +227,13 @@ label before_main_menu:
 
 label quit:
     python:
+        # Remove any consequences from not quitting properly
+        if not Natsuki.getForceQuitAttempt():
+            Natsuki.removeApology(jn_apologies.ApologyTypes.sudden_leave)
+            
+            if Natsuki.getQuitApology() == jn_apologies.ApologyTypes.sudden_leave:
+                Natsuki.clearQuitApology()
+
         # Save game data
         jn_utils.save_game()
 

--- a/game/stickers.rpy
+++ b/game/stickers.rpy
@@ -26,7 +26,7 @@ init 0 python in jn_stickers:
 
     class StickerTypes(Enum):
         """
-        Identifiers for different weather objects, used for sanity checks when changing weather.
+        Identifiers for different sticker types, used for determining which sticker graphic to show when peeping it.
         """
         blank = 1
         blank_cheer = 2

--- a/game/zz_config.rpy
+++ b/game/zz_config.rpy
@@ -1,4 +1,4 @@
 init 25:
     # Allows us to define our own quit behaviour by jumping to a label on force quit, instead of defaulting to Confirm screen
     # If you touch this, or break this, I will destroy you - Blizz :)
-    define config.quit_action = Function(quit_input_check)
+    define config.quit_action = Function(quitInputCheck)


### PR DESCRIPTION
Resolves the following:

- Issue where consequences for force quitting could be avoided by repeatedly selecting the close option on the game window
- Issue where force quitting and backing out repeatedly could result in the game restarting from the greeting, due to Ren'Py falling out of context
- Patch some function names to match newer conventions
- Fix some incorrect documentation

Closes #850 