### PR TITLE
Feature/staying active refresh

### DIFF
--- a/game/script-farewells.rpy
+++ b/game/script-farewells.rpy
@@ -154,7 +154,7 @@ label farewell_force_quit:
     play audio glitch_c
 
     n 1uskem "H-{w=0.3}huh?{w=1}{nw}"
-    extend 4uscwr " N-{w=0.3}no!{w=0.2} Wait!!{w=0.2} PLEASE-{w=0.3}{nw}"
+    extend 4uscwr " N-{w=0.3}no!{w=0.2} Wait!!{w=0.2} PLEASE-{w=0.1}{nw}"
     show natsuki 4kchupltsa at jn_center zorder JN_NATSUKI_ZORDER
 
     play audio static

--- a/game/script-topics.rpy
+++ b/game/script-topics.rpy
@@ -1299,7 +1299,7 @@ init 5 python:
             label="talk_staying_active",
             unlocked=True,
             prompt="Staying active",
-            conditional="persistent.jn_total_visit_count >= 10",
+            conditional="persistent.jn_total_visit_count >= 5",
             category=["Life", "You", "Health"],
             nat_says=True,
             affinity_range=(jn_affinity.HAPPY, None),
@@ -1309,30 +1309,157 @@ init 5 python:
     )
 
 label talk_staying_active:
-    n 1nnmbo "Hey,{w=0.1} [player]..."
-    n 3nllsr "You should get out more."
-    n 1fsqsm "..."
-    n 4fchbg "Ahaha!{w=0.2} No,{w=0.1} really!{w=0.2} I'm serious!"
-    n 1ulraj "At school,{w=0.1} it was super easy to get exercise since we had to walk everywhere,{w=0.1} and we had sports and such..."
-    n 1nsqsf "It's not so straightforward when you have a job and other stuff to worry about,{w=0.1} though."
-    n 2fllss "I'm not gonna lie and say I worked out or anything like that..."
-    n 1ullaj "But I tried to get some walks in when I could.{w=0.5}{nw}"
-    extend 4uchgn " Any excuse to hit the bookshop is reason enough for me!"
-    n 2kslsl "...Or {i}was{/i} reason enough, anyway."
-    n 1fllaj "But still {w=0.1}-{w=0.5}{nw}"
-    extend 1unmbg " you should give it a shot too,{w=0.1} [player]!"
-    n 1nlrss "It doesn't have to be a hike or anything crazy{w=0.1} -{w=0.3}{nw}"
-    extend 1nnmsm " it's more about keeping at it,{w=0.1} really."
-    n 1fchsm "Even a daily ten minute walk will help you feel refreshed and awake!"
-    n 4ullaj "So...{w=0.5}{nw}"
-    extend 4fnmss " make sure you get out soon,{w=0.1} [player]."
+    $ already_discussed_topic = get_topic("talk_staying_active").shown_count > 0
+    if already_discussed_topic:
+        n 3ccsss "Heh.{w=0.75}{nw}"
+        extend 7csqss " Well then,{w=0.2} [player]."
+        n 7fcsbg "I think it's just about time for a little update."
+        n 3fllss "You know..."
+        n 4fsqss "About that whole{w=0.5}{nw}"
+        extend 4fsgbg " {i}'staying active'{/i}{w=0.5}{nw}"
+        extend 4fnmbg " stuff we talked about before?"
+        n 2fsqsm "..."
+        n 2fsqbg "What?{w=0.75}{nw}"
+        extend 1fcsbs " Don't you remember?{w=0.75}{nw}"
+        extend 4fcssmesm " Did you totally forget or something {i}already{/i}?"
+        n 3fcsbs "Well,{w=0.2} too bad!"
+        n 7flrbg "Last time I checked,{w=0.5}{nw}" 
+        extend 3fsqbg " you still had to be sitting around on your butt to actually spend any time with me.{w=0.75}{nw}"
+        extend 3cllaj " So..." 
+        n 7csqsm "As far as I'm concerned?"
+        n 6fcsbg "I {i}totally{/i} reserve the right to grill you about it whenever I want!"
+        
+        if Natsuki.isEnamored(higher=True):
+            n 3ccsbgl "Besides,{w=0.2} [player].{w=0.75}{nw}"
+            extend 4clrsslsbl " We both know {i}someone{/i} has to keep an eye on you.{w=0.75}{nw}"
+            $ chosen_tease = jn_utils.getRandomTease().capitalize()
+            extend 2ccspol " [chosen_tease]."
+            n 4fsqbgl "...And who could be better suited to the job than yours truly,{w=0.2} right?{w=0.75}{nw}"
+            extend 4fsqsml " Ehehe."
+            n 5ccsajl "W-{w=0.2}well,{w=0.2} anyway.{w=0.75}{nw}"
 
+        elif Natsuki.isAffectionate(higher=True):
+            n 4ccsajl "A-{w=0.2}and besides!"
+            n 2ccsbg "Someone has to keep tabs and make sure you aren't just slacking off,{w=0.5}{nw}"
+            extend 2csqpo " or laying around like a potato for hours."
+            n 5ccsaj "A-{w=0.2}anyway.{w=0.75}{nw}"
+            
+        else:
+            n 4fsqsm "Ehehe."
+            n 4fllbg "Well,{w=0.2} whatever.{w=0.75}{nw}"
+
+        extend 2tlrfl " It's like I said before though -{w=0.5}{nw}"
+        extend 2tnmaj " when I was at school?"
+        n 5ccsajsbr "Before all of this,{w=0.2} o-{w=0.2}obviously."
+
+    else:
+        n 7tllsl "..."
+        n 7cllpu "...Huh."
+        n 3ullaj "You know,{w=0.2} [player]...{w=1}{nw}"
+        extend 3tnmsl " I've been thinking.{w=0.75}{nw}"
+        extend 4tlrfl " About how you visit me and all."
+        n 4csrss "And well...{w=0.75}{nw}"
+        extend 1ccsaj " I'm sorry,{w=0.2} but it just {i}has{/i} be said."
+        n 2csqfl "You {w=0.2}{i}really{/i}{w=0.5} need to get out more."
+        n 2csqsl "..."
+        n 2fsqsm "..."
+        n 4fchgnesm "Pffft-!"
+        n 4fchbg "No,{w=0.2} really!{w=0.75}{nw}"
+        extend 3fsqbg " Just hear me out,{w=0.2} will you?{w=0.75}{nw}"
+        extend 6fcstr " I'm being serious here,{w=0.2} you know."
+        n 1fcsaj "So."
+        n 2ulraj "I don't know about you,{w=0.2} [player].{w=0.75}{nw}"
+        extend 2cnmss " But at least when I was at school?"
+        n 2ccsflsbl "B-{w=0.2}before all of {i}this{/i},{w=0.2} I mean."
+
+    n 4unmbo "It was actually {i}super{/i} easy to get a load of exercise just from being stuck at school all day every week."
+    n 4unmfl "Really -{w=0.5}{nw}"
+    extend 7tsrpu " I'm actually kinda surprised I never mentioned it before.{w=0.75}{nw}"
+    extend 3unmbo " But it isn't like we were {i}always{/i} stuck in this stupid clubroom or anything."
+    n 3tllbo "Sure,{w=0.2} we all had our own homerooms and stuff.{w=0.75}{nw}"
+    extend 7tnmfl " But if we had any kind of special lessons,{w=0.2} or lab class?"
+    n 7tnmbo "Then we'd just have to pack up our stuff and go to whichever room had all the equipment."
+    n 3csqem "...And you could guarantee it was always at some random end of the building too.{w=0.75}{nw}"
+    extend 4csrem " Gross."
+    n 4clraj "So with all the constant trekking around the classrooms,{w=0.5}{nw}" 
+    extend 2csgfl " {i}and{/i} the lame excuse for a lunch break we got?"
+    n 2cllfl "Well..."
+    n 1ccsaj "Let's just say that you were {i}definitely{/i} gonna be staying in shape one way or another."
+    n 1ccsss "Heh."
+    n 2tsqfl "And if that wasn't doing it for you,{w=0.2} [player]?"
+    n 4csrem "Then you could bet your lunch money that the all sports and gym lessons would.{w=0.75}{nw}"
+    extend 4csrsl " Whether you liked it or not."
+    n 1ccsemesi "Ugh."
+    n 1unmfl "I mean,{w=0.5}{nw}"
+    extend 4cllajsbr " don't get me wrong -{w=0.5}{nw}"
+    extend 2ccsposbr " it isn't like I'm just moaning for the sake of it!"
+    n 2cslss "And it {i}was{/i} pretty cool being able to stay in decent shape without dumping all my time and money at the gym..."
+    
+    if get_topic("talk_skateboarding").shown_count > 0:
+        n 4cllbo "...Especially if I was already trying to save for something else,{w=0.2} like I said before.{w=0.75}{nw}"
+        extend 4cdlss " With the skateboard and all."
+
+        if get_topic("talk_work_experience").shown_count > 0:
+            n 5cllflsbl "Plus all the work placement stuff later on."
+
+        n 2fcstrlsbr "N-{w=0.2}not that it made it any less of a pain in the backside,{w=0.2} obviously."
+    
+    else:
+        n 2cslfl "...Even if it was a complete pain in the backside."
+    
+    n 2cllca "..."
+    n 2tllpu "But...{w=1}{nw}"
+
+    if already_discussed_topic:
+        extend 2tsqss " what about you,{w=0.2} [player]?{w=0.75}{nw}"
+        extend 4fcsss " Guess I gotta remind you yet again,{w=0.2} huh."
+
+    else:
+        extend 4tnmbo " what about you though,{w=0.2} [player]?"
+
+    n 7ccsaj "I don't know if you take any classes now or what,{w=0.5}{nw}"
+    extend 3fcsgs " but don't think just because you aren't marching around a school all day means you get to be a total slob either."
+    n 1fsqsm "Ehehe.{w=0.75}{nw}"
+    extend 4fcsbs " Yep!"
+    n 2fcsgs "Whatever it is -{w=0.5}{nw}"
+    extend 2flraj " running errands,{w=0.5}{nw}"
+    extend 2fnmbg " slogging it out at the gym,{w=0.5}{nw}"
+    extend 4fsqbg " or that ten minute walk you always put off?"
+    n 4fcssmesm "Everyone stands to gain from getting the blood pumping for once!{w=0.75}{nw}"
+    extend 7fcsbg " It's just common sense,{w=0.2} [player]."
+    n 6fnmbg "Take it from me:{w=0.5}{nw}"
+    extend 6ccsbg " you can practically {i}guarantee{/i} it'll have you feeling refreshed and awake in no time!"
+    
     if Natsuki.isEnamored(higher=True):
-        n 3fchbg "I wanna see you fighting fit!{w=0.5}{nw}"
-        extend 3uchsm " Ehehe."
-        return
+        n 2ulrbg "And hey,{w=0.2} who knows?{w=0.75}{nw}"
+        extend 4tsgbg " If you {i}actually{/i} put enough effort into it?"
+        n 5ccsbglsbr "T-{w=0.2}then maybe you won't be the {i}only{/i} one getting pumped.{w=0.75}{nw}"
+        extend 5csrdvlsbr " Ehehe."
 
-    n 1fchbl "It's the least you can do!"
+        if Natsuki.isLove(higher=True):
+            $ chosen_endearment = jn_utils.getRandomEndearment()
+            n 3fcsbgl "L-{w=0.2}love you too,{w=0.2} [player]~!"
+
+        else:
+            n 4ccsbglemesbr "B-{w=0.2}better hop to it,{w=0.2} [player]!"
+
+    else:
+        n 6csqsm "..."
+        n 7tsqss "Oh?{w=0.75}{nw}"
+        extend 7fsgbg " What's that?"
+        n 3fnmbs "What's with the sudden deer caught in headlights look,{w=0.2} [player]?{w=0.75}{nw}"
+        extend 3fsqsm " Ehehe."
+        n 4fcsbg "Well don't you worry.{w=0.75}{nw}"
+        extend 4fsqbg " With {i}my{/i} help?"
+
+        if Natsuki.isAffectionate(higher=True):
+            n 3fchgn "We'll make an active-living pro out of you in no time!"
+            n 6fchbgedz "You're welcome,{w=0.2} [player]!"
+        
+        else:
+            n 3fcsbs "We'll have those legs of yours moving for once in no time!"
+            n 7fcsbgesm "Better remember to thank me later,{w=0.2} [player]!"
+
     return
 
 # Natsuki discusses stress and offers ways she finds useful to deal with it


### PR DESCRIPTION
Introduces the following:

- `talk_staying_active` topic completely rewritten, accounting for whether the topic has been seen before and to comply with current writing standards
- Slightly reduced the visit count required for the `talk_staying_active` topic
- Slight timing adjustment to the first-time sudden leave farewell