### PR TITLE
Bugfix/Conditionswitch idle sprite replacement

### DIFF
--- a/game/natsuki.rpy
+++ b/game/natsuki.rpy
@@ -382,6 +382,32 @@ init 0 python:
         # START: Relationship functionality
 
         @staticmethod
+        def getIdleImageTagsForAffinity():
+            """
+            Returns the idle image tags/name for Natsuki based on her current affinity state.
+
+            OUT:
+                - String image tags/name
+            """
+            if Natsuki.isEnamored(higher=True):
+                return "natsuki idle enamored"
+
+            elif Natsuki.isAffectionate(higher=True):
+                return "natsuki idle affectionate"
+
+            elif Natsuki.isHappy(higher=True):
+                return "natsuki idle happy"
+
+            elif Natsuki.isNormal(higher=True):
+                return "natsuki idle normal"
+            
+            elif Natsuki.isDistressed(higher=True):
+                return "natsuki idle distressed"
+
+            else:
+                return "natsuki idle ruined"
+
+        @staticmethod
         def calculatedAffinityGain(base=1, bypass=False):
             """
             Adds a calculated amount to affinity, based on the player's relationship with Natsuki and daily cap state.

--- a/game/outfits.rpy
+++ b/game/outfits.rpy
@@ -2155,6 +2155,19 @@ init -1 python in jn_outfits:
 
 # Asking Natsuki to wear an outfit
 label outfits_wear_outfit:
+    python:
+        # We have to unload outfits before wearables due to dependencies
+        jn_outfits.unloadCustomOutfits()
+        jn_outfits.unloadCustomWearables()
+
+        # We have to load wearables before outfits due to dependencies
+        jn_outfits.loadCustomWearables()
+        jn_outfits.loadCustomOutfits()
+
+        # Now we've loaded back into memory, reload the persisted data
+        jn_outfits.JNWearable.loadAll()
+        jn_outfits.JNOutfit.loadAll()
+
     if not jn_outfits.getAllOutfits():
         # No outfits, no point proceeding
         n 4tnmbo "Huh?{w=0.5}{nw}"
@@ -2826,7 +2839,7 @@ label outfits_auto_change:
     else:
         n 2fsqsl "...{w=0.75}{nw}"
 
-    show natsuki idle at jn_center
+    $ jnShowNatsukiIdle(jn_center) 
     return
 
 label new_wearables_outfits_unlocked:

--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -245,8 +245,7 @@ label ch30_init:
 
 #The main loop
 label ch30_loop:
-    if not renpy.showing("natsuki idle"):
-        show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
+    $ jnShowNatsukiIdle(jn_center)  
 
     #Run our checks
     python:
@@ -287,10 +286,8 @@ label ch30_wait:
 
         if not jn_topic_in_event_list("weather_change") and jn_locations.checkUpdateLocationSunriseSunset(main_background):
             queue("weather_change")
-        
-        if (random.randint(1, 10000) == 1):
-            jn_stickers.stickerWindowPeekUp(at_right=random.choice([True, False]))
 
+        jnShowNatsukiIdle(jn_center)  
         jnPause(delay=5.0, hard=True)
 
     jump ch30_loop
@@ -300,7 +297,7 @@ label call_next_topic(show_natsuki=True):
     $ _topic = None
 
     if show_natsuki:
-        show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
+        $ jnShowNatsukiIdle(jn_center)  
 
     if persistent._event_list:
         $ _topic = persistent._event_list.pop(0)
@@ -770,7 +767,7 @@ label farewell_menu:
     $ Natsuki.setForceQuitAttempt(False)
 
     if isinstance(_return, basestring):
-        show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
+        $ jnShowNatsukiIdle(jn_center)  
         $ push(_return)
         jump call_next_topic
 
@@ -787,7 +784,7 @@ label outfits_menu:
         "mod_assets/icons/outfits.png")
 
     if isinstance(_return, basestring):
-        show natsuki idle at jn_center zorder JN_NATSUKI_ZORDER
+        $ jnShowNatsukiIdle(jn_center)  
         $ push(_return)
         jump call_next_topic
 

--- a/game/sprite-backend.rpy
+++ b/game/sprite-backend.rpy
@@ -1325,16 +1325,7 @@ image natsuki option_wait_sulky:
 
     repeat
 
-# This selects which idle image to show based on current affinity state
-image natsuki idle = ConditionSwitch(
-    "Natsuki.isEnamored(higher=True)", "natsuki idle enamored",
-    "Natsuki.isAffectionate(higher=True)", "natsuki idle affectionate",
-    "Natsuki.isHappy(higher=True)", "natsuki idle happy",
-    "Natsuki.isNormal(higher=True)", "natsuki idle normal",
-    "Natsuki.isDistressed(higher=True)", "natsuki idle distressed",
-    "True", "natsuki idle ruined",
-    predict_all = True
-)
+image natsuki idle = Natsuki.getIdleImageTagsForAffinity()
 
 # Idle images for ENAMORED+
 image natsuki idle enamored:
@@ -1931,6 +1922,14 @@ image natsuki idle fluster:
 
 init python:
     import random
+
+    def jnShowNatsukiIdle(position, zorder=store.JN_NATSUKI_ZORDER):
+        """
+        Shows the appropriate Natsuki idle sprite based on the current affinity level.
+        Avoids having to use a condition switch to constantly check and update the sprite,
+        which is extremely expensive in CPU cycles.
+        """
+        renpy.show(Natsuki.getIdleImageTagsForAffinity(), at_list=[position], zorder=zorder)
 
     def jnShowNatsukiTalkMenu():
         """


### PR DESCRIPTION
Resolves the following:

- Issue where the use of Ren'Py's `ConditionSwitch` function in generating/updating the idle sprite for Natsuki resulted in excess CPU usage and poor performance; switched to on-demand idle sprite replacement through a new function `jnShowNatsukiIdle`

Closes #887 