### PR TITLE
Disable skip bindings

### DIFF
--- a/game/script-ch30.rpy
+++ b/game/script-ch30.rpy
@@ -8,6 +8,9 @@ label ch30_autoload:
         in_sayori_kill = None
         config.skipping = False
         config.allow_skipping = False
+        config.keymap['skip'] = []
+        config.keymap['toggle_skip'] = []
+        config.keymap['fast_skip'] = []
         config.predict_statements = 5
         config.image_cache_size = 128
         n.display_args["callback"] = jnNoDismissDialogue


### PR DESCRIPTION
While skipping is already disabled, toggle_skip is unfortunately unaffected due to a bug in the current version of Ren'Py. To work around this, remove the toggle_skip keybinding, and for good measure remove the related ones as well.